### PR TITLE
Automate passive income accrual

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/main.py
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from typing import Dict, Any
-import time, hashlib, random
+import time, hashlib, random, math
 
 INCOME_PERIOD = 300  # 5 минут
 INCOME_AMOUNT = 50
@@ -57,7 +57,32 @@ def ensure_user(u: str, gender: str = "other", appearance: dict | None = None):
         STATE["users"][u] = {"coins": 500, "password": "", "gender": gender, "appearance": appearance or random_appearance()}
         STATE["inv"][u] = [dict(x) for x in DEFAULT_INV]
         STATE["positions"][u] = {"x": 520, "y": 340}
-        STATE["last_income"][u] = 0
+        STATE["last_income"][u] = time.time()
+
+
+def apply_passive_income(username: str) -> bool:
+    """Начисляет пассивный доход за завершённые циклы.
+
+    Возвращает True, если монеты были начислены.
+    """
+    ensure_user(username)
+    now = time.time()
+    last = STATE["last_income"].get(username)
+    if last is None:
+        STATE["last_income"][username] = now
+        return False
+
+    elapsed = now - last
+    if elapsed < INCOME_PERIOD:
+        return False
+
+    cycles = int(elapsed // INCOME_PERIOD)
+    if cycles <= 0:
+        return False
+
+    STATE["users"][username]["coins"] += cycles * INCOME_AMOUNT
+    STATE["last_income"][username] = last + cycles * INCOME_PERIOD
+    return True
 
 def current_slots(u: str):
     equip = {}
@@ -112,6 +137,7 @@ async def api_login(username: str = Form(...), password: str = Form(...)):
 @app.get("/api/me")
 async def me(username: str):
     ensure_user(username)
+    apply_passive_income(username)
     return {"username": username, "coins": STATE["users"][username]["coins"]}
 
 @app.get("/api/appearance")
@@ -130,23 +156,22 @@ async def save_appearance(username: str = Form(...), skin: str = Form(...), hair
 @app.get("/api/income_left")
 async def income_left(username: str):
     ensure_user(username)
+    granted = apply_passive_income(username)
     now = time.time()
-    last = STATE["last_income"].get(username, 0)
-    left = max(0, INCOME_PERIOD - int(now - last))
-    return {"left": left, "period": INCOME_PERIOD, "amount": INCOME_AMOUNT}
+    last = STATE["last_income"].get(username, now)
+    left = max(0, math.ceil(INCOME_PERIOD - (now - last)))
+    return {"left": left, "period": INCOME_PERIOD, "amount": INCOME_AMOUNT, "granted": granted}
 
 @app.post("/api/claim_income")
 async def claim_income(username: str = Form(...)):
     ensure_user(username)
+    granted = apply_passive_income(username)
+    if granted:
+        await broadcast({"type": "coins", "name": username})
     now = time.time()
-    last = STATE["last_income"].get(username, 0)
-    delta = now - last
-    if delta < INCOME_PERIOD:
-        return {"ok": False, "left": int(INCOME_PERIOD - delta)}
-    STATE["last_income"][username] = now
-    STATE["users"][username]["coins"] += INCOME_AMOUNT
-    await broadcast({"type": "coins", "name": username})
-    return {"ok": True}
+    last = STATE["last_income"].get(username, now)
+    left = max(0, math.ceil(INCOME_PERIOD - (now - last)))
+    return {"ok": True, "granted": granted, "left": left, "coins": STATE["users"][username]["coins"]}
 
 @app.get("/api/shop")
 async def api_shop():
@@ -155,6 +180,7 @@ async def api_shop():
 @app.post("/api/buy")
 async def api_buy(username: str = Form(...), item_id: int = Form(...)):
     ensure_user(username)
+    apply_passive_income(username)
     item = next((x for x in STATE["shop"] if x["id"] == int(item_id)), None)
     if not item:
         return {"ok": False, "error": "Товар не найден"}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
@@ -21,34 +21,34 @@ async function refreshMe(){
   const me=await api("/api/me?username="+encodeURIComponent(username));
   document.querySelectorAll("#coins").forEach(el=>el.textContent=me.coins);
 }
-let incomeTimerId=null, leftSec=300;
-function setClaimEnabled(en){
-  const btn=document.getElementById("claim"); if(!btn) return;
-  btn.disabled = !en;
-  btn.style.opacity = en ? "1" : ".6";
-}
+let incomeTimerId=null, incomeSyncId=null, leftSec=300;
 function renderIncomeTimer(){
   const el=document.getElementById("income-timer"); if(!el) return;
-  if(leftSec<=0){ el.textContent="⏳ готово"; setClaimEnabled(true); return; }
-  setClaimEnabled(false);
-  const m=String(Math.floor(leftSec/60)).padStart(2,'0');
-  const s=String(leftSec%60).padStart(2,'0');
+  const value=Math.max(0, Math.floor(leftSec));
+  const m=String(Math.floor(value/60)).padStart(2,'0');
+  const s=String(value%60).padStart(2,'0');
   el.textContent=`⏳ ${m}:${s}`;
 }
-async function initIncomeTimer(){
+async function syncIncomeLeft(){
   try{
     const j=await api("/api/income_left?username="+encodeURIComponent(username));
-    leftSec = (typeof j.left==="number") ? j.left : 300;
-  }catch(e){ leftSec=300; }
+    if(typeof j.left==="number") leftSec = j.left;
+    if(j.granted) await refreshMe();
+  }catch(e){ /* ignore */ }
   renderIncomeTimer();
-  if(incomeTimerId) clearInterval(incomeTimerId);
-  incomeTimerId=setInterval(()=>{ if(leftSec>0){ leftSec--; renderIncomeTimer(); } },1000);
 }
-async function claimCoins(){
-  const f=new FormData(); f.append("username",username);
-  const j=await api("/api/claim_income","POST",f);
-  if(!j.ok){ await initIncomeTimer(); alert("Подождите ещё: "+(j.left||0)+" сек."); return; }
-  await refreshMe(); await initIncomeTimer();
+async function initIncomeTimer(){
+  await syncIncomeLeft();
+  if(incomeTimerId) clearInterval(incomeTimerId);
+  incomeTimerId=setInterval(()=>{
+    if(leftSec>0){
+      leftSec--; renderIncomeTimer();
+    }else{
+      syncIncomeLeft();
+    }
+  },1000);
+  if(incomeSyncId) clearInterval(incomeSyncId);
+  incomeSyncId=setInterval(syncIncomeLeft,15000);
 }
 
 // Online overlay

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -50,7 +50,7 @@
         <canvas id="char-canvas" width="280" height="280"></canvas>
         <div class="coins-line">
           Монеты: <b id="coins">...</b>
-          <button id="claim">+50/5мин</button>
+          <span class="auto-income-note">Автопополнение каждые 5 минут</span>
           <span id="income-timer" class="countdown">⏳ 05:00</span>
         </div>
         <div class="equipped" id="equipped-list"></div>


### PR DESCRIPTION
## Summary
- add a reusable passive income helper and update API endpoints to award coins automatically
- extend income API responses with refresh signals and keep purchases in sync with new coin totals
- refresh the character modal UI and timer logic to reflect automatic income instead of manual claiming

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68d7f2c7b734832aad987ea25aba6cde