### PR TITLE
Reorder registration fields after customization options

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
@@ -48,22 +48,6 @@
             <label><input type="radio" name="gender" value="other" checked> Не определился</label>
           </div>
 
-          <div class="row grid2">
-            <div>
-              <label class="lbl">Имя игрока</label>
-              <input id="r-username" placeholder="минимум 3 символа" autocomplete="username">
-              <div class="hint" id="r-u-err"></div>
-            </div>
-            <div class="pw">
-              <label class="lbl">Пароль</label>
-              <div class="pw-wrap">
-                <input id="r-password" type="password" placeholder="минимум 6 символов" autocomplete="new-password">
-                <button class="pw-eye" type="button" data-for="r-password">👁</button>
-              </div>
-              <div class="hint" id="r-p-err"></div>
-            </div>
-          </div>
-
           <div class="row">
             <div class="hint-row">
               <label class="lbl">Цвет кожи</label>
@@ -99,6 +83,22 @@
               <span class="small-muted">характер и настроение</span>
             </div>
             <div id="emotion-sw" class="emotion-row"></div>
+          </div>
+
+          <div class="row grid2">
+            <div>
+              <label class="lbl">Имя игрока</label>
+              <input id="r-username" placeholder="минимум 3 символа" autocomplete="username">
+              <div class="hint" id="r-u-err"></div>
+            </div>
+            <div class="pw">
+              <label class="lbl">Пароль</label>
+              <div class="pw-wrap">
+                <input id="r-password" type="password" placeholder="минимум 6 символов" autocomplete="new-password">
+                <button class="pw-eye" type="button" data-for="r-password">👁</button>
+              </div>
+              <div class="hint" id="r-p-err"></div>
+            </div>
           </div>
 
           <div class="actions">


### PR DESCRIPTION
## Summary
- move the registration name and password row to the bottom of the creator-left column so customization choices appear first
- keep the Create Account action after the credentials fields to preserve logical form order

## Testing
- Viewed http://127.0.0.1:8000/auth in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d7fa2a2958832ab6a6050718b8d62c