### PR TITLE
Adjust grid layout responsiveness

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -79,6 +79,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 @media (max-width: 640px){
   .char-grid{grid-template-columns:1fr}
   .creator{grid-template-columns:1fr}
+  .grid2{grid-template-columns:1fr;row-gap:12px}
 }
 
 /* --- Creator swatches --- */


### PR DESCRIPTION
## Summary
- ensure the two-column grid2 layout stacks into a single column on screens 640px wide or smaller
- keep spacing between inputs consistent for the stacked layout via an explicit row gap

## Testing
- `pip install -r requirements.txt` *(fails: unable to download packages due to proxy restrictions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fa28c818832aaedf4c2a1315aa21