### PR TITLE
Add shop balance indicator to shop modal

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -35,6 +35,8 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .char-preview{background:#f7f9ff;border:1px solid #e2e9fb;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:14px}
 .char-header{display:flex;flex-direction:column;gap:12px}
 .coins-line{display:flex;gap:10px;align-items:center;margin:8px 0}
+.shop-balance{display:flex;gap:8px;align-items:center;padding:6px 12px;border-radius:999px;background:#f7f9ff;border:1px solid #e2e9fb;font-weight:600;color:#1e293b;font-size:14px}
+.shop-balance b{font-weight:800;color:#0f172a}
 .countdown{color:#334155;font-weight:700}
 .emotion-control{margin:12px 0}
 .equipped{display:flex;flex-wrap:wrap;gap:10px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
@@ -97,9 +97,15 @@ function formatItemType(type){
 }
 
 // Coins
+function updateShopBalance(coins){
+  const shopEl=document.getElementById("shop-coins");
+  if(shopEl && typeof coins!=="undefined") shopEl.textContent=coins;
+}
 async function refreshMe(){
   const me=await api("/api/me?username="+encodeURIComponent(username));
   document.querySelectorAll("#coins").forEach(el=>el.textContent=me.coins);
+  updateShopBalance(me.coins);
+  return me;
 }
 let incomeTimerId=null, incomeSyncId=null, leftSec=300;
 function renderIncomeTimer(){
@@ -207,7 +213,12 @@ document.getElementById("btn-character").addEventListener("click", async ()=>{
   scheduleEmotionPanelLayout();
   await initIncomeTimer();
 });
-document.getElementById("btn-shop").addEventListener("click", ()=>{ shopModal.hidden=false; loadShop(); });
+document.getElementById("btn-shop").addEventListener("click", async ()=>{
+  shopModal.hidden=false;
+  const me=await refreshMe();
+  updateShopBalance(me.coins);
+  await loadShop();
+});
 document.getElementById("char-close").addEventListener("click", ()=>{ charModal.hidden=true; });
 document.getElementById("shop-close").addEventListener("click", ()=>{ shopModal.hidden=true; });
 [charModal,shopModal].forEach(m=>m.addEventListener("click",(e)=>{ if(e.target===m) m.hidden=true; }));
@@ -225,7 +236,9 @@ async function loadShop(){
       const f=new FormData(); f.append("item_id",it.id); f.append("username",username);
       const r=await fetch("/api/buy",{method:"POST",body:f}); const j=await r.json();
       if(!j.ok) return alert(j.error||"Ошибка");
-      await refreshMe(); await loadInventory(); await refreshAvatar();
+      const me=await refreshMe();
+      updateShopBalance(me.coins);
+      await loadInventory(); await refreshAvatar();
     });
     box.appendChild(card);
   });

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -86,6 +86,7 @@
   <div class="modal-box">
     <div class="modal-header">
       <div class="title">Магазин</div>
+      <div class="shop-balance">Монеты: <b id="shop-coins">...</b></div>
       <button class="ghost close" id="shop-close">✕</button>
     </div>
     <div id="shop" class="inventory-grid"></div>


### PR DESCRIPTION
## Summary
- add a shop coin balance element to the shop modal header
- style the new balance badge to align with existing currency visuals
- refresh the displayed coin amount when opening the shop and after purchases

## Testing
- no automated tests (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d806722bfc832aa90096fa95f69318