### PR TITLE
Adjust shop modal scrolling behaviour

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -28,6 +28,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.32);display:grid;place-items:center;z-index:50}
 .modal[hidden]{display:none}
 .modal-box{width:min(980px,94vw);max-height:88vh;overflow:auto;background:#ffffff;border:1px solid #e4e9f8;border-radius:16px;box-shadow:0 10px 50px rgba(0,0,0,.15);padding:16px;display:flex;flex-direction:column}
+.modal-box.shop-box{overflow:hidden;display:flex;flex-direction:column;gap:16px}
 .modal-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;gap:12px}
 .modal .title{font-size:18px;font-weight:800}
 
@@ -45,6 +46,8 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .slot{background:#fff;border:2px dashed #c7d2fe;border-radius:12px;padding:14px;cursor:pointer;text-align:center;min-height:72px;display:flex;align-items:center;justify-content:center}
 .slot.active{border-style:solid;background:#eef4ff}
 .inventory-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:14px}
+.modal-box.shop-box .coins-line{margin:0}
+#shop{flex:1;min-height:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:4px 4px 16px}
 .shop-categories{display:flex;gap:10px;margin-bottom:16px;overflow-x:auto;padding-bottom:6px;scrollbar-width:none;-ms-overflow-style:none}
 .shop-categories::-webkit-scrollbar{display:none}
 .shop-category{flex:0 0 auto;padding:8px 16px;border-radius:999px;border:1px solid #d5def6;background:#f5f7ff;color:#1e293b;cursor:pointer;font-weight:600;transition:transform .12s ease,box-shadow .12s ease,border-color .12s ease,background .12s ease,color .12s ease}
@@ -99,6 +102,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 
 @media (max-width: 640px){
   .modal-box{width:100vw;height:100vh;max-height:100vh;border-radius:0;padding:20px 16px 16px;display:flex;flex-direction:column;overflow:hidden}
+  .modal-box.shop-box{gap:12px;padding:20px 14px 16px}
   .modal-header{margin-bottom:12px}
   .char-grid{flex:1;display:flex;flex-direction:column;gap:16px;overflow:hidden}
   .char-preview{height:360px;flex:0 0 auto;overflow:auto}
@@ -106,6 +110,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
   .inventory-scroll{flex:1;min-height:0;overflow-y:auto;padding-right:4px}
   .char-inventory .slot-bar{grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:16px}
   .inventory-grid{grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:16px;padding-bottom:8px}
+  #shop{padding:0 2px 16px}
   .slot{min-height:80px}
   .item{min-height:80px}
   .equip-pill{padding:10px 16px;font-size:15px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -83,7 +83,7 @@
 </div>
 
 <div class="modal" id="shop-modal" hidden>
-  <div class="modal-box">
+  <div class="modal-box shop-box">
     <div class="modal-header">
       <div class="title">Магазин</div>
       <button class="ghost close" id="shop-close">✕</button>


### PR DESCRIPTION
## Summary
- add a dedicated class to the shop modal container so it can be styled separately from the character modal
- update shop modal layout rules so only the item list scrolls while the header and categories stay fixed
- refine mobile spacing to preserve the new scrolling behaviour on small screens

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d829e47e88832abe73b00f2882388c