### PR TITLE
Align avatar head scaling across canvases

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
@@ -22,6 +22,7 @@ const SCALE_PREVIEW = 3.0;
 const NAME_BASE_PX = 12;
 const NAME_SCENE_PX = Math.round(NAME_BASE_PX * SCALE_SCENE) + 10;
 const NAME_PREVIEW_PX = Math.round(NAME_BASE_PX * SCALE_PREVIEW) + 10;
+const HEAD_RADIUS_BASE = 12;
 
 const EMOTIONS = [
   {value:'smile',label:'Улыбка',icon:'🙂'},
@@ -471,8 +472,7 @@ function drawMiniOn(ctx2, p, scale=SCALE_SCENE, withName=true){
     ctx2.fillRect(bx+6*scale,by+40*scale,24*scale,5*scale);
   }
 
-  const isLargePreview = !withName && scale >= SCALE_PREVIEW;
-  const headRadius = (isLargePreview ? 12 : 6) * scale;
+  const headRadius = HEAD_RADIUS_BASE * scale;
   const headCx = p.x;
   const headCy = by + 10*scale;
   drawHead(ctx2, headCx, headCy, headRadius, skin);


### PR DESCRIPTION
## Summary
- ensure the avatar head radius derives from a single base constant so stage and preview canvases keep matching proportions
- keep the dependent face and hair positioning tied to the new radius for consistent rendering

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000


------
https://chatgpt.com/codex/tasks/task_e_68d8e00e7b20832aad3124bca41fc628