### PR TITLE
Adjust hat placement to align with head geometry

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
@@ -479,12 +479,17 @@ function drawMiniOn(ctx2, p, scale=SCALE_SCENE, withName=true){
   const headRadius = (isLargePreview ? 12 : 6) * scale;
   const headCx = p.x;
   const headCy = by + 10*scale;
+  const headTop = headCy - headRadius;
   drawHead(ctx2, headCx, headCy, headRadius, skin);
   const faceScale = headRadius / 36;
   const hairTop = headCy - (headRadius * (2/3));
   drawHair(ctx2, style, hair, headCx, hairTop, faceScale);
   drawExpression(ctx2, emotion, headCx, headCy, eyes, faceScale);
-  if(p.equip && p.equip.head){ ctx2.fillStyle="#e94560"; ctx2.fillRect(bx+6*scale,by+0*scale,24*scale,4*scale); }
+  if(p.equip && p.equip.head){
+    ctx2.fillStyle="#e94560";
+    const hatTop = headTop - 4*scale;
+    ctx2.fillRect(headCx - headRadius, hatTop, headRadius * 2, 4*scale);
+  }
   if(p.equip && p.equip.accessory){ ctx2.fillStyle="#f8b500"; ctx2.beginPath(); ctx2.arc(p.x,by+26*scale,4*scale,0,Math.PI*2); ctx2.fill(); }
 
   if(withName){


### PR DESCRIPTION
## Summary
- capture the head top position when drawing character minis
- reposition equipped headwear using head-centric coordinates so the hat sits just above the head on all scales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e66960a0832aa8e0cc03eb992c5c