### PR TITLE
Switch hairstyle picker to select control

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -74,7 +74,8 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .auth-card .row{margin:10px 0}
 .auth-card input, .auth-card select{width:100%;padding:12px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.35);background:rgba(255,255,255,.12);color:#fff}
 .gender-select-row .select-wrap{position:relative}
-.pill-select{appearance:none;-webkit-appearance:none;-moz-appearance:none;padding-right:38px;background:rgba(255,255,255,.12) url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E") no-repeat right 14px center;background-size:12px auto}
+.pill-select{appearance:none;-webkit-appearance:none;-moz-appearance:none;padding-right:44px;border-radius:999px;background-color:rgba(255,255,255,.12);background-image:url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E"),linear-gradient(135deg,rgba(106,162,255,.32),rgba(91,140,255,.14));background-repeat:no-repeat,no-repeat;background-position:right 14px center,center;background-size:12px auto,100% 100%;box-shadow:0 0 0 1px rgba(106,162,255,.18) inset}
+.pill-select option{color:#0f172a;background:#fff}
 .pill-select:focus{outline:2px solid rgba(106,162,255,.6);outline-offset:2px}
 .gender-select-row .small-muted{margin-left:auto}
 .auth-card .actions{display:flex;gap:10px;margin-top:8px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
@@ -80,8 +80,13 @@
           </div>
 
           <div class="row">
-            <label class="lbl">Причёска</label>
-            <div id="styles-wrap" class="select-inline"></div>
+            <div class="hint-row">
+              <label class="lbl" for="style-select">Причёска</label>
+              <span class="small-muted">подбираем под выбранный пол</span>
+            </div>
+            <div class="select-wrap">
+              <select id="style-select" class="pill-select"></select>
+            </div>
           </div>
 
           <div class="row">
@@ -189,6 +194,18 @@ try{
   if(stored.emotion && EMOTIONS.some(e=>e.value===stored.emotion)){ state.emotion=stored.emotion; appearanceLoaded=true; }
 }catch(e){}
 
+function persistAppearanceState(){
+  try{
+    localStorage.setItem('cp_appearance', JSON.stringify({
+      skin: state.skin,
+      hair: state.hair,
+      eyes: state.eyes,
+      style: state.style,
+      emotion: state.emotion
+    }));
+  }catch(e){}
+}
+
 function randomizeAppearanceFor(g){
   const genderKey = g||'other';
   state.skin = SKINS[Math.floor(Math.random()*SKINS.length)];
@@ -233,21 +250,26 @@ function makeSwatches(id, arr, cls){
   }
 }
 function makeStyles(){
+  const select=document.getElementById('style-select');
+  if(!select) return;
   const g=genderValue();
   const list=STYLES[g]||STYLES.other;
-  const box=document.getElementById('styles-wrap'); box.innerHTML="";
   const preferred = list.includes(state.style)?state.style:list[0];
   state.style = preferred;
+  select.innerHTML="";
   list.forEach((name)=>{
-    const b=document.createElement('button'); b.type='button'; b.className='badge'; b.textContent=hairLabel(name);
-    b.dataset.val=name;
-    b.addEventListener('click',()=>{
-      box.querySelectorAll('.badge').forEach(x=>x.dataset.selected=0);
-      b.dataset.selected=1; state.style=name; redrawPreview();
-    });
-    if(name===preferred) b.dataset.selected=1;
-    box.appendChild(b);
+    const opt=document.createElement('option');
+    opt.value=name;
+    opt.textContent=hairLabel(name);
+    select.appendChild(opt);
   });
+  select.value=preferred;
+  select.onchange=()=>{
+    state.style=select.value;
+    persistAppearanceState();
+    redrawPreview();
+  };
+  persistAppearanceState();
 }
 function updateEmotionScrollMask(box){
   if(!box) return;


### PR DESCRIPTION
## Summary
- replace the hairstyle badge group with a labeled select control backed by the STYLES list
- persist style selection changes and refresh the avatar preview when the dropdown changes
- update the shared pill-select styling so the new control matches the gender selector

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e8614434832ab625ba4d14ff67f4