### PR TITLE
Adjust auth preview header layout

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -96,7 +96,9 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .pw-eye{position:absolute;right:6px;top:50%;transform:translateY(-50%);background:transparent;border:0;color:#fff;cursor:pointer}
 
 .creator{display:grid;grid-template-columns:1fr 260px;gap:16px}
-.creator-right{display:grid;place-items:center;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.2);border-radius:12px;padding:10px}
+.creator-right{display:flex;flex-direction:column;align-items:center;gap:12px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.2);border-radius:12px;padding:12px}
+.preview-header{align-self:stretch;display:flex;justify-content:flex-end;margin:0}
+.preview-emotion{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.25);color:#fff;font-size:13px;font-weight:600;min-height:0}
 .small{font-size:12px}
 .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .grid3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
@@ -119,8 +119,10 @@
         </div>
 
         <div class="creator-right">
+          <div class="preview-header">
+            <div id="preview-emotion" class="preview-emotion"></div>
+          </div>
           <canvas id="preview" width="260" height="260"></canvas>
-          <div class="muted small">Превью персонажа</div>
         </div>
       </div>
     </div>
@@ -163,6 +165,21 @@ const EMOTIONS=[
   {value:'surprised',label:'Удивление',icon:'😯'},
   {value:'sleepy',label:'Сонный',icon:'😴'}
 ];
+const previewEmotionEl=document.getElementById('preview-emotion');
+function getEmotionMeta(val){
+  return EMOTIONS.find(e=>e.value===val);
+}
+function updateEmotionBadge(){
+  if(!previewEmotionEl) return;
+  const meta=getEmotionMeta(state.emotion);
+  if(meta){
+    previewEmotionEl.textContent=`${meta.icon} ${meta.label}`;
+    previewEmotionEl.dataset.emotion=meta.value;
+  }else{
+    previewEmotionEl.textContent='';
+    previewEmotionEl.dataset.emotion='';
+  }
+}
 const GENDER_OUTFITS={
   male:{primary:'#3a6ea5',secondary:'#2e4f79',accent:'#1f2f57'},
   female:{primary:'#f19ad9',secondary:'#d16ec7',accent:'#ffd6ef'},
@@ -289,7 +306,10 @@ function makeStyles(){
 }
 function makeEmotions(){
   const select=document.getElementById('emotion-select');
-  if(!select) return;
+  if(!select){
+    updateEmotionBadge();
+    return;
+  }
   const current=state.emotion;
   select.innerHTML="";
   EMOTIONS.forEach(em=>{
@@ -306,10 +326,12 @@ function makeEmotions(){
     redrawPreview();
     syncAppearanceStorage();
   }
+  updateEmotionBadge();
   if(select.dataset.bound!=="1"){
     select.addEventListener('change',()=>{
       const next=select.value||'smile';
       state.emotion=next;
+      updateEmotionBadge();
       redrawPreview();
       syncAppearanceStorage();
     });


### PR DESCRIPTION
## Summary
- replace the auth preview header text with an emotion badge container and keep the preview structure intact
- adjust the creator preview styling so the header removal does not leave awkward spacing
- update the registration script to keep the preview emotion badge in sync with the selected emotion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8ebb01b7c832a800f51366ae6494e