### PR TITLE
Fix syntax error in auth page emotion badge script

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
@@ -181,7 +181,6 @@ function updateEmotionBadge(){
     previewEmotionEl.dataset.emotion='';
   }
 }
-};
 
 // Hairstyles catalog by gender
 const STYLES = {


### PR DESCRIPTION
## Summary
- remove the stray closing token after updateEmotionBadge so the inline auth script parses correctly

## Testing
- Loaded /auth in the browser and confirmed the avatar preview renders without console errors

------
https://chatgpt.com/codex/tasks/task_e_68d907714a24832ab6c1241b07035097