### PR TITLE
Refine avatar hair layering and add preview

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/avatar_drawing.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/avatar_drawing.js
@@ -39,7 +39,7 @@
     ctx.restore();
   }
 
-  function drawHair(ctx, style, color, cx, hairlineY, scale=1){
+  function drawHair(ctx, style, color, cx, hairlineY, scale=1, layer='both'){
     if(!ctx || !color) return;
     const s = scale || 1;
     const headRadius = 36 * s;
@@ -64,6 +64,9 @@
       braids: 3.0
     };
     const thickness = (thicknessMap[style] || 3.2) * s;
+
+    const layerKey = layer === 'front' ? 'front' : layer === 'back' ? 'back' : 'both';
+    const shouldRender = part => layerKey === 'both' || layerKey === part;
 
     ctx.save();
     ctx.lineJoin = 'round';
@@ -263,67 +266,115 @@
 
     switch(style){
       case 'short':
-        drawCap(1.65, 0.58, 0.62, 0.36);
-        drawFringeSegments(3, 0.32, 0.28);
+        if(shouldRender('back')){
+          drawCap(1.65, 0.58, 0.62, 0.36);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(3, 0.32, 0.28);
+        }
         break;
       case 'fade':
-        drawShavedBand(0.48, 2.1, 0.75, -60);
-        drawCap(1.7, 0.5, 0.58, 0.34);
-        drawFringeSegments(2, 0.27, 0.22, {highlightAlpha:0.16});
+        if(shouldRender('back')){
+          drawShavedBand(0.48, 2.1, 0.75, -60);
+          drawCap(1.7, 0.5, 0.58, 0.34);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(2, 0.27, 0.22, {highlightAlpha:0.16});
+        }
         break;
       case 'buzz':
-        drawShavedBand(0.32, 1.9, 0.7, -54);
-        drawCap(1.55, 0.38, 0.48, 0.28);
+        if(shouldRender('back')){
+          drawShavedBand(0.32, 1.9, 0.7, -54);
+          drawCap(1.55, 0.38, 0.48, 0.28);
+        }
         break;
       case 'undercut':
-        drawShavedBand(0.6, 2.2, 0.82, -68);
-        drawCap(1.82, 0.66, 0.6, 0.4);
-        drawFringeSegments(2, 0.3, 0.3, {highlightAlpha:0.2});
+        if(shouldRender('back')){
+          drawShavedBand(0.6, 2.2, 0.82, -68);
+          drawCap(1.82, 0.66, 0.6, 0.4);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(2, 0.3, 0.3, {highlightAlpha:0.2});
+        }
         break;
       case 'mohawk':
-        drawShavedBand(0.62, 2.4, 0.65, -70);
-        drawMohawk(0.9, 1.15);
+        if(shouldRender('back')){
+          drawShavedBand(0.62, 2.4, 0.65, -70);
+          drawMohawk(0.9, 1.15);
+        }
         break;
       case 'curly':
-        drawCap(1.75, 0.62, 0.68, 0.42);
-        drawCurlRow(6, 0.18, 0.68);
-        drawCurlRow(5, 0.16, 0.92, {highlightAlpha:0.18});
+        if(shouldRender('back')){
+          drawCap(1.75, 0.62, 0.68, 0.42);
+        }
+        if(shouldRender('front')){
+          drawCurlRow(6, 0.18, 0.68);
+          drawCurlRow(5, 0.16, 0.92, {highlightAlpha:0.18});
+        }
         break;
       case 'afro':
-        drawAfro(1.32);
+        if(shouldRender('back')){
+          drawAfro(1.32);
+        }
         break;
       case 'ponytail':
-        drawTail(0, 2.05, 0.68, {highlightAlpha:0.18});
-        drawCap(1.68, 0.6, 0.64, 0.36);
-        drawFringeSegments(2, 0.28, 0.24, {highlightAlpha:0.18});
+        if(shouldRender('back')){
+          drawTail(0, 2.05, 0.68, {highlightAlpha:0.18});
+          drawCap(1.68, 0.6, 0.64, 0.36);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(2, 0.28, 0.24, {highlightAlpha:0.18});
+        }
         break;
       case 'pixie':
-        drawCap(1.6, 0.5, 0.56, 0.32);
-        drawFringeSegments(4, 0.38, 0.42, {highlightShift:0.28, highlightAlpha:0.24});
+        if(shouldRender('back')){
+          drawCap(1.6, 0.5, 0.56, 0.32);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(4, 0.38, 0.42, {highlightShift:0.28, highlightAlpha:0.24});
+        }
         break;
       case 'bob':
-        drawCap(1.88, 0.98, 0.62, 0.52);
-        drawFringeSegments(4, 0.3, 0.3, {highlightAlpha:0.2});
+        if(shouldRender('back')){
+          drawCap(1.88, 0.98, 0.62, 0.52);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(4, 0.3, 0.3, {highlightAlpha:0.2});
+        }
         break;
       case 'long':
-        drawTail(-0.92, 2.4, 0.52, {highlightAlpha:0.18});
-        drawTail(0.92, 2.4, 0.52, {highlightAlpha:0.18, highlightShift:0.32});
-        drawCap(1.9, 1.18, 0.66, 0.52);
-        drawFringeSegments(3, 0.34, 0.28, {highlightAlpha:0.2});
+        if(shouldRender('back')){
+          drawTail(-0.92, 2.4, 0.52, {highlightAlpha:0.18});
+          drawTail(0.92, 2.4, 0.52, {highlightAlpha:0.18, highlightShift:0.32});
+          drawCap(1.9, 1.18, 0.66, 0.52);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(3, 0.34, 0.28, {highlightAlpha:0.2});
+        }
         break;
       case 'bun':
-        drawCap(1.7, 0.58, 0.62, 0.36);
-        drawBun(0.38, 0);
-        drawFringeSegments(2, 0.26, 0.24, {highlightAlpha:0.18});
+        if(shouldRender('back')){
+          drawCap(1.7, 0.58, 0.62, 0.36);
+          drawBun(0.38, 0);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(2, 0.26, 0.24, {highlightAlpha:0.18});
+        }
         break;
       case 'braids':
-        drawCap(1.78, 0.62, 0.66, 0.44);
-        drawBraidChain(-0.72, 4, 0.18, 0.42);
-        drawBraidChain(0.72, 4, 0.18, 0.42);
+        if(shouldRender('back')){
+          drawCap(1.78, 0.62, 0.66, 0.44);
+          drawBraidChain(-0.72, 4, 0.18, 0.42);
+          drawBraidChain(0.72, 4, 0.18, 0.42);
+        }
         break;
       default:
-        drawCap(1.72, 0.6, 0.64, 0.4);
-        drawFringeSegments(2, 0.28, 0.25, {highlightAlpha:0.18});
+        if(shouldRender('back')){
+          drawCap(1.72, 0.6, 0.64, 0.4);
+        }
+        if(shouldRender('front')){
+          drawFringeSegments(2, 0.28, 0.25, {highlightAlpha:0.18});
+        }
         break;
     }
 

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/characterRenderer.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/characterRenderer.js
@@ -653,6 +653,8 @@
     const headCx = centerX;
     const headCy = torsoY - headRadius - 1.2*scale;
     const headTop = headCy - headRadius;
+    const faceScale = headRadius / 36;
+    const hairTop = headCy - (headRadius * 0.82);
     const rawNeckTop = headCy + headRadius - Math.max(2.4*scale, headRadius*0.24);
     const neckBaseY = torsoY + 1.6*scale;
     const neckTopY = Math.min(rawNeckTop, neckBaseY - 0.8*scale);
@@ -888,13 +890,16 @@
     };
 
     drawAccessories(ctx, palette, metrics, scale, equip, 'back');
+    ctx.save();
+    drawHair(ctx, appearance.style, appearance.hair, headCx, hairTop, faceScale, 'back');
+    ctx.restore();
     drawHead(ctx, headCx, headCy, headRadius, appearance.skin);
     drawLowerOutfit(ctx, palette, metrics, scale, {equip, gender:genderKey});
     drawUpperOutfit(ctx, palette, metrics, scale, {equip, gender:genderKey});
+    ctx.save();
+    drawHair(ctx, appearance.style, appearance.hair, headCx, hairTop, faceScale, 'front');
+    ctx.restore();
     drawAccessories(ctx, palette, metrics, scale, equip, 'front');
-    const faceScale = headRadius / 36;
-    const hairTop = headCy - (headRadius * 0.82);
-    drawHair(ctx, appearance.style, appearance.hair, headCx, hairTop, faceScale);
     drawExpression(ctx, appearance.emotion, headCx, headCy, appearance.eyes, faceScale);
 
     if(equip.head){

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/tests/hair_layer_preview.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/tests/hair_layer_preview.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Hair Layer Preview</title>
+  <style>
+    body {
+      font-family: "Inter", system-ui, sans-serif;
+      background: #f5f5f5;
+      margin: 0;
+      padding: 24px;
+      color: #1f2933;
+    }
+    h1 {
+      font-size: 20px;
+      margin-bottom: 12px;
+    }
+    p {
+      margin: 0 0 16px;
+      max-width: 680px;
+      line-height: 1.5;
+    }
+    canvas {
+      background: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+      display: block;
+      max-width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <h1>Hair Layering Preview</h1>
+  <p>
+    Each avatar is rendered with the new layered hair routine. The bulk of the hairstyle is painted
+    behind the head, while the fringe accents sit above the skin yet below facial features.
+  </p>
+  <canvas id="hair-layer-preview" width="720" height="320"></canvas>
+  <script src="../js/avatar_drawing.js"></script>
+  <script>
+    (function(){
+      if(!window.AvatarDrawing){
+        return;
+      }
+      const canvas = document.getElementById('hair-layer-preview');
+      const ctx = canvas.getContext('2d');
+      const centerY = 170;
+      const headRadius = 36;
+      const hairlineY = centerY - (headRadius * 0.82);
+      const skin = '#f5d0a9';
+      const eyes = '#1f2a48';
+      const styles = [
+        {style: 'short', hair: '#2f2b2b', label: 'Short'},
+        {style: 'ponytail', hair: '#6b3f1f', label: 'Ponytail'},
+        {style: 'curly', hair: '#3a2f4f', label: 'Curly'},
+        {style: 'long', hair: '#1f4058', label: 'Long'}
+      ];
+      styles.forEach((entry, index) => {
+        const cx = 90 + index * 160;
+        AvatarDrawing.drawHair(ctx, entry.style, entry.hair, cx, hairlineY, 1, 'back');
+        AvatarDrawing.drawHead(ctx, cx, centerY, headRadius, skin);
+        AvatarDrawing.drawHair(ctx, entry.style, entry.hair, cx, hairlineY, 1, 'front');
+        AvatarDrawing.drawExpression(ctx, 'smile', cx, centerY, eyes, 1);
+        ctx.save();
+        ctx.fillStyle = '#1f2933';
+        ctx.textAlign = 'center';
+        ctx.font = '500 16px Inter, system-ui, sans-serif';
+        ctx.fillText(entry.label, cx, 300);
+        ctx.restore();
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split hair rendering helpers into back and front layers with a new drawHair layer argument
- render back hair before the head and fringe after outfits in characterRenderer
- add a static canvas preview that showcases hair styles with the new layering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d90f308f24832aab330f1a37569f1e