### PR TITLE
Fix shaved hair gradient layering

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/avatar_drawing.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/avatar_drawing.js
@@ -195,6 +195,18 @@
       ctx.restore();
     }
 
+    function renderShavedBand(heightMul, widthMul, alpha, tint){
+      if(shouldRender('front')){
+        drawShavedBand(heightMul, widthMul, alpha, tint);
+        return true;
+      }
+      if(shouldRender('back')){
+        drawShavedBand(heightMul, widthMul, alpha, tint);
+        return true;
+      }
+      return false;
+    }
+
     function drawCurlRow(count, radiusMul, offsetMul, options={}){
       const radius = headRadius * radiusMul;
       const startX = cx - headRadius * 1.1;
@@ -275,33 +287,33 @@
         break;
       case 'fade':
         if(shouldRender('back')){
-          drawShavedBand(0.48, 2.1, 0.75, -60);
           drawCap(1.7, 0.5, 0.58, 0.34);
         }
+        renderShavedBand(0.48, 2.1, 0.75, -60);
         if(shouldRender('front')){
           drawFringeSegments(2, 0.27, 0.22, {highlightAlpha:0.16});
         }
         break;
       case 'buzz':
         if(shouldRender('back')){
-          drawShavedBand(0.32, 1.9, 0.7, -54);
           drawCap(1.55, 0.38, 0.48, 0.28);
         }
+        renderShavedBand(0.32, 1.9, 0.7, -54);
         break;
       case 'undercut':
         if(shouldRender('back')){
-          drawShavedBand(0.6, 2.2, 0.82, -68);
           drawCap(1.82, 0.66, 0.6, 0.4);
         }
+        renderShavedBand(0.6, 2.2, 0.82, -68);
         if(shouldRender('front')){
           drawFringeSegments(2, 0.3, 0.3, {highlightAlpha:0.2});
         }
         break;
       case 'mohawk':
         if(shouldRender('back')){
-          drawShavedBand(0.62, 2.4, 0.65, -70);
           drawMohawk(0.9, 1.15);
         }
+        renderShavedBand(0.62, 2.4, 0.65, -70);
         break;
       case 'curly':
         if(shouldRender('back')){

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/tests/hair_layer_preview.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/tests/hair_layer_preview.html
@@ -32,8 +32,9 @@
 <body>
   <h1>Hair Layering Preview</h1>
   <p>
-    Each avatar is rendered with the new layered hair routine. The bulk of the hairstyle is painted
-    behind the head, while the fringe accents sit above the skin yet below facial features.
+    Each avatar is rendered with the layered hair routine. The bulk of the hairstyle is painted
+    behind the head, while the fringe accents sit above the skin yet below facial features. The fade,
+    buzz, and undercut examples confirm the shaved gradient is rendered over the scalp again.
   </p>
   <canvas id="hair-layer-preview" width="720" height="320"></canvas>
   <script src="../js/avatar_drawing.js"></script>
@@ -50,13 +51,17 @@
       const skin = '#f5d0a9';
       const eyes = '#1f2a48';
       const styles = [
-        {style: 'short', hair: '#2f2b2b', label: 'Short'},
+        {style: 'fade', hair: '#2f2b2b', label: 'Fade'},
+        {style: 'buzz', hair: '#5c4638', label: 'Buzz'},
+        {style: 'undercut', hair: '#27354f', label: 'Undercut'},
+        {style: 'short', hair: '#383030', label: 'Short'},
         {style: 'ponytail', hair: '#6b3f1f', label: 'Ponytail'},
-        {style: 'curly', hair: '#3a2f4f', label: 'Curly'},
-        {style: 'long', hair: '#1f4058', label: 'Long'}
+        {style: 'curly', hair: '#3a2f4f', label: 'Curly'}
       ];
+      const spacing = 120;
+      const startX = 80;
       styles.forEach((entry, index) => {
-        const cx = 90 + index * 160;
+        const cx = startX + index * spacing;
         AvatarDrawing.drawHair(ctx, entry.style, entry.hair, cx, hairlineY, 1, 'back');
         AvatarDrawing.drawHead(ctx, cx, centerY, headRadius, skin);
         AvatarDrawing.drawHair(ctx, entry.style, entry.hair, cx, hairlineY, 1, 'front');


### PR DESCRIPTION
## Summary
- ensure shaved hair gradients render during the front layer pass while keeping bulk hair in back
- extend the hair layer preview to showcase fade, buzz, and undercut gradients

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9130f9098832ab0d641d4e31c547a