### PR TITLE
Refactor avatar outfit rendering into layered module

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/characterRenderer.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/characterRenderer.js
@@ -4,6 +4,10 @@
   const drawHead = avatar.drawHead;
   const drawHair = avatar.drawHair;
   const drawExpression = avatar.drawExpression;
+  const outfitLayers = global.AvatarOutfitLayers || {};
+  const renderEquipmentLayers = typeof outfitLayers.renderEquipmentLayers === 'function'
+    ? outfitLayers.renderEquipmentLayers
+    : null;
   const hasHelpers = typeof drawHead === 'function' && typeof drawHair === 'function' && typeof drawExpression === 'function';
 
   const EMOTIONS = ['smile','neutral','frown','surprised','sleepy'];
@@ -324,352 +328,6 @@
     ctx.restore();
   }
 
-  function drawUpperOutfit(ctx, palette, metrics, scale, options){
-    const {centerX, torsoY, torsoHeight}=metrics;
-    const contour=metrics.torsoContour || {};
-    const neckBaseY=contour.neckBaseY != null ? contour.neckBaseY : torsoY;
-    const shoulderY=contour.shoulderY != null ? contour.shoulderY : torsoY + 4*scale;
-    const chestY=contour.chestY != null ? contour.chestY : torsoY + 8*scale;
-    const waistY=contour.waistY != null ? contour.waistY : torsoY + torsoHeight*0.55;
-    const hipY=(contour.hipY != null ? contour.hipY : torsoY + torsoHeight) - 1.1*scale;
-    const neckHalf=contour.neckHalf != null ? contour.neckHalf : (metrics.torsoWidth||20*scale)/2;
-    const shoulderHalf=contour.shoulderHalf != null ? contour.shoulderHalf : neckHalf + 2*scale;
-    const chestHalf=contour.chestHalf != null ? contour.chestHalf : shoulderHalf-0.8*scale;
-    const waistHalf=contour.waistHalf != null ? contour.waistHalf : chestHalf-2.4*scale;
-    const hipHalf=contour.hipHalf != null ? contour.hipHalf : waistHalf+1.4*scale;
-    const {equip={}, gender='other'}=options || {};
-    const hasEquip=!!equip.upper;
-    const colors=palette.upper||{};
-    const baseColor=colors.base||'#5c7ab2';
-    const highlight=colors.highlight||baseColor;
-    const shadow=colors.shadow||baseColor;
-    const collarDrop=hasEquip ? 0.45*scale : 0.2*scale;
-    const collarDip=hasEquip ? 1.8*scale : 1.1*scale;
-    const outerOffset=hasEquip ? 1.6*scale : 0.9*scale;
-    const hemSpread=hasEquip ? 1.8*scale : 1.2*scale;
-    const waistEase=hasEquip ? 0.6*scale : (gender==='female' ? 0.4*scale : 0.1*scale);
-    ctx.save();
-    const grad=ctx.createLinearGradient(centerX, neckBaseY-collarDip, centerX, hipY+3*scale);
-    grad.addColorStop(0, highlight);
-    grad.addColorStop(0.55, baseColor);
-    grad.addColorStop(1, shadow);
-    ctx.fillStyle=grad;
-    ctx.beginPath();
-    ctx.moveTo(centerX - neckHalf - outerOffset*0.4, neckBaseY - collarDrop);
-    ctx.quadraticCurveTo(centerX - neckHalf*0.6, neckBaseY - collarDrop - collarDip, centerX, neckBaseY - collarDrop - collarDip*0.75);
-    ctx.quadraticCurveTo(centerX + neckHalf*0.6, neckBaseY - collarDrop - collarDip, centerX + neckHalf + outerOffset*0.4, neckBaseY - collarDrop);
-    ctx.quadraticCurveTo(centerX + shoulderHalf + outerOffset, shoulderY, centerX + chestHalf + outerOffset*0.5, chestY);
-    ctx.quadraticCurveTo(centerX + waistHalf + waistEase, waistY + 0.4*scale, centerX + hipHalf + hemSpread, hipY);
-    ctx.quadraticCurveTo(centerX, hipY + 0.8*scale, centerX - hipHalf - hemSpread, hipY);
-    ctx.quadraticCurveTo(centerX - (waistHalf + waistEase), waistY + 0.4*scale, centerX - (chestHalf + outerOffset*0.5), chestY);
-    ctx.quadraticCurveTo(centerX - (shoulderHalf + outerOffset), shoulderY, centerX - neckHalf - outerOffset*0.4, neckBaseY - collarDrop);
-    ctx.closePath();
-    ctx.fill();
-
-    if(colors.stroke){
-      ctx.strokeStyle=colors.stroke;
-      ctx.lineWidth=Math.max(1,1.25*scale);
-      ctx.stroke();
-    }
-
-    if(colors.trim){
-      const beltHeight=Math.max(1.6*scale, scale);
-      const beltY=waistY + 0.6*scale;
-      ctx.fillStyle=colors.trim;
-      ctx.beginPath();
-      ctx.moveTo(centerX - waistHalf - 0.8*scale, beltY);
-      ctx.quadraticCurveTo(centerX, beltY + 0.4*scale, centerX + waistHalf + 0.8*scale, beltY);
-      ctx.lineTo(centerX + waistHalf + 0.7*scale, beltY + beltHeight);
-      ctx.quadraticCurveTo(centerX, beltY + beltHeight + 0.35*scale, centerX - waistHalf - 0.7*scale, beltY + beltHeight);
-      ctx.closePath();
-      ctx.fill();
-    }
-
-    if(colors.highlight && hasEquip){
-      ctx.strokeStyle=colors.highlight;
-      ctx.lineWidth=0.85*scale;
-      ctx.beginPath();
-      ctx.moveTo(centerX, neckBaseY - collarDrop - collarDip*0.5);
-      ctx.quadraticCurveTo(centerX, waistY + 0.6*scale, centerX, hipY - 0.3*scale);
-      ctx.stroke();
-    }
-
-    ctx.restore();
-  }
-
-  function drawLowerOutfit(ctx, palette, metrics, scale, options){
-    const {hipY, kneeY, shoeTop, centerX}=metrics;
-    const contour=metrics.torsoContour || {};
-    const legProfiles=metrics.legs || {};
-    const leftLeg=legProfiles.left;
-    const rightLeg=legProfiles.right;
-    const {equip={}, gender='other'}=options || {};
-    const hasEquip=!!equip.lower;
-    const colors=palette.lower||{};
-    const baseColor=colors.base||'#4a668d';
-    const highlight=colors.highlight||baseColor;
-    const shadow=colors.shadow||baseColor;
-    const waistY=contour.waistY != null ? contour.waistY : (hipY-6*scale);
-    const hipTop=(contour.hipY != null ? contour.hipY : hipY) - 0.4*scale;
-    ctx.save();
-    const grad=ctx.createLinearGradient(centerX, waistY, centerX, shoeTop);
-    grad.addColorStop(0, highlight);
-    grad.addColorStop(0.65, baseColor);
-    grad.addColorStop(1, shadow);
-
-    const fallback=()=>{
-      ctx.fillStyle=grad;
-      const torsoX=metrics.torsoX || (centerX-(metrics.torsoWidth||20*scale)/2);
-      const torsoWidth=metrics.torsoWidth || 20*scale;
-      const legInset=3*scale;
-      const crotchWidth=4*scale;
-      const legWidth=(torsoWidth-crotchWidth)/2;
-      ctx.beginPath();
-      ctx.moveTo(torsoX+legInset, hipY);
-      ctx.quadraticCurveTo(torsoX+legInset+legWidth*0.2, kneeY, torsoX+4*scale, shoeTop);
-      ctx.lineTo(torsoX+12*scale, shoeTop);
-      ctx.quadraticCurveTo(torsoX+legInset+legWidth*0.8, kneeY-2*scale, centerX-crotchWidth/2, hipY+2*scale);
-      ctx.lineTo(centerX-crotchWidth/2, hipY);
-      ctx.closePath();
-      ctx.fill();
-      ctx.beginPath();
-      ctx.moveTo(centerX+crotchWidth/2, hipY);
-      ctx.lineTo(centerX+crotchWidth/2, hipY+2*scale);
-      ctx.quadraticCurveTo(torsoX+torsoWidth-legInset-legWidth*0.8, kneeY-2*scale, torsoX+torsoWidth-4*scale, shoeTop);
-      ctx.lineTo(torsoX+torsoWidth-4*scale, shoeTop);
-      ctx.quadraticCurveTo(torsoX+torsoWidth-legInset-legWidth*0.2, kneeY, torsoX+torsoWidth-legInset, hipY);
-      ctx.closePath();
-      ctx.fill();
-    };
-
-    if(!leftLeg || !rightLeg){
-      fallback();
-      ctx.restore();
-      return;
-    }
-
-    ctx.fillStyle=grad;
-
-    if(!hasEquip && gender==='female'){
-      ctx.beginPath();
-      ctx.moveTo(leftLeg.hipOuterX - 1.1*scale, hipTop);
-      ctx.quadraticCurveTo(centerX, hipTop + 1.7*scale, rightLeg.hipOuterX + 1.1*scale, hipTop);
-      ctx.quadraticCurveTo(rightLeg.ankleOuterX + 3.2*scale, shoeTop + 3.5*scale, centerX, shoeTop + 6.2*scale);
-      ctx.quadraticCurveTo(leftLeg.ankleOuterX - 3.2*scale, shoeTop + 3.5*scale, leftLeg.hipOuterX - 1.1*scale, hipTop);
-      ctx.closePath();
-      ctx.fill();
-      if(colors.stroke){
-        ctx.strokeStyle=colors.stroke;
-        ctx.lineWidth=Math.max(1,1.1*scale);
-        ctx.stroke();
-      }
-      if(colors.trim){
-        ctx.strokeStyle=colors.trim;
-        ctx.lineWidth=0.85*scale;
-        ctx.beginPath();
-        ctx.moveTo(leftLeg.hipOuterX - 0.8*scale, hipTop + 0.6*scale);
-        ctx.quadraticCurveTo(centerX, hipTop + 2.2*scale, rightLeg.hipOuterX + 0.8*scale, hipTop + 0.6*scale);
-        ctx.stroke();
-      }
-      ctx.restore();
-      return;
-    }
-
-    const outerInset=hasEquip ? 1.3*scale : 0.8*scale;
-    const seamInset=hasEquip ? 1.1*scale : 0.7*scale;
-    ctx.beginPath();
-    ctx.moveTo(leftLeg.hipOuterX - outerInset, hipTop);
-    ctx.quadraticCurveTo(leftLeg.kneeOuterX - outerInset*0.4, kneeY + 0.2*scale, leftLeg.ankleOuterX - outerInset*0.1, shoeTop);
-    ctx.lineTo(leftLeg.ankleInnerX + seamInset*0.4, shoeTop);
-    ctx.quadraticCurveTo(leftLeg.kneeInnerX + seamInset*0.35, kneeY, centerX - seamInset*0.45, hipY - 0.2*scale);
-    ctx.quadraticCurveTo(centerX, hipY + 0.5*scale, centerX + seamInset*0.45, hipY - 0.2*scale);
-    ctx.quadraticCurveTo(rightLeg.kneeInnerX - seamInset*0.35, kneeY, rightLeg.ankleInnerX - seamInset*0.4, shoeTop);
-    ctx.lineTo(rightLeg.ankleOuterX + outerInset*0.1, shoeTop);
-    ctx.quadraticCurveTo(rightLeg.kneeOuterX + outerInset*0.4, kneeY + 0.2*scale, rightLeg.hipOuterX + outerInset, hipTop);
-    ctx.quadraticCurveTo(centerX, hipTop + 1.4*scale, leftLeg.hipOuterX - outerInset, hipTop);
-    ctx.closePath();
-    ctx.fill();
-
-    if(colors.stroke){
-      ctx.strokeStyle=colors.stroke;
-      ctx.lineWidth=Math.max(1,1.05*scale);
-      ctx.stroke();
-    }
-
-    if(colors.trim){
-      ctx.strokeStyle=colors.trim;
-      ctx.lineWidth=0.8*scale;
-      ctx.beginPath();
-      ctx.moveTo(centerX, hipTop + 0.4*scale);
-      ctx.quadraticCurveTo(centerX, hipY + 0.8*scale, centerX, shoeTop-0.8*scale);
-      ctx.stroke();
-    }
-
-    ctx.restore();
-  }
-
-  function drawAccessories(ctx, palette, metrics, scale, equip, phase){
-    const {torsoX, torsoY, torsoWidth, torsoHeight, shoeTop, shoeHeight, footBaseline, centerX, headCy, headRadius}=metrics;
-    const equipment = equip || {};
-    const currentPhase = phase || 'front';
-    if(currentPhase==='back' && equipment.cloak){
-      const colors=palette.cloak||{};
-      ctx.save();
-      const grad=ctx.createLinearGradient(centerX, torsoY, centerX, footBaseline);
-      grad.addColorStop(0, colors.highlight||colors.base||'#0f3460');
-      grad.addColorStop(0.7, colors.base||'#0f3460');
-      grad.addColorStop(1, colors.shadow||colors.edge||'#071f2a');
-      ctx.fillStyle=grad;
-      const topY=torsoY+2*scale;
-      ctx.beginPath();
-      ctx.moveTo(torsoX-5*scale, topY);
-      ctx.quadraticCurveTo(centerX-6*scale, headCy+headRadius*0.6, torsoX-4*scale, footBaseline-2*scale);
-      ctx.quadraticCurveTo(centerX, footBaseline+6*scale, torsoX+torsoWidth+4*scale, footBaseline-2*scale);
-      ctx.quadraticCurveTo(centerX+6*scale, headCy+headRadius*0.6, torsoX+torsoWidth+5*scale, topY);
-      ctx.closePath();
-      ctx.fill();
-      const edgeColor=colors.edge||colors.stroke;
-      if(edgeColor){
-        ctx.strokeStyle=edgeColor;
-        ctx.lineWidth=Math.max(1,1.4*scale);
-        ctx.stroke();
-      }
-      if(colors.lining){
-        ctx.strokeStyle=colors.lining;
-        ctx.lineWidth=0.9*scale;
-        ctx.beginPath();
-        ctx.moveTo(torsoX-3*scale, topY+2*scale);
-        ctx.quadraticCurveTo(centerX-5*scale, headCy+headRadius*0.7, torsoX-2*scale, footBaseline-3*scale);
-        ctx.moveTo(torsoX+torsoWidth+3*scale, topY+2*scale);
-        ctx.quadraticCurveTo(centerX+5*scale, headCy+headRadius*0.7, torsoX+torsoWidth+2*scale, footBaseline-3*scale);
-        ctx.stroke();
-      }
-      ctx.restore();
-      return;
-    }
-
-    if(currentPhase!=='front') return;
-
-    const shoeColors=palette.shoes||{};
-    ctx.save();
-    const legs=metrics.legs||{};
-    const leftLeg=legs.left;
-    const rightLeg=legs.right;
-    const fallbackShoes=()=>{
-      const shoeGrad=ctx.createLinearGradient(centerX, shoeTop, centerX, shoeTop+shoeHeight);
-      shoeGrad.addColorStop(0, shoeColors.highlight||shoeColors.base||'#666');
-      shoeGrad.addColorStop(0.6, shoeColors.base||'#444');
-      shoeGrad.addColorStop(1, shoeColors.shadow||shoeColors.trim||'#222');
-      ctx.fillStyle=shoeGrad;
-      const leftToe=torsoX+3*scale;
-      const rightToe=torsoX+torsoWidth+5*scale;
-      ctx.beginPath();
-      ctx.moveTo(leftToe, shoeTop);
-      ctx.quadraticCurveTo(leftToe-2*scale, shoeTop+shoeHeight*0.7, leftToe+2*scale, shoeTop+shoeHeight);
-      ctx.lineTo(rightToe-2*scale, shoeTop+shoeHeight);
-      ctx.quadraticCurveTo(rightToe+2*scale, shoeTop+shoeHeight*0.7, rightToe-2*scale, shoeTop);
-      ctx.closePath();
-      ctx.fill();
-      if(shoeColors.stroke){
-        ctx.strokeStyle=shoeColors.stroke;
-        ctx.lineWidth=Math.max(1,1.2*scale);
-        ctx.stroke();
-      }
-      if(shoeColors.trim){
-        ctx.strokeStyle=shoeColors.trim;
-        ctx.lineWidth=0.8*scale;
-        ctx.beginPath();
-        ctx.moveTo(leftToe+4*scale, shoeTop+shoeHeight*0.35);
-        ctx.quadraticCurveTo(centerX, shoeTop+shoeHeight*0.15, rightToe-6*scale, shoeTop+shoeHeight*0.35);
-        ctx.stroke();
-      }
-    };
-
-    const drawShoe=(leg)=>{
-      if(!leg) return;
-      const ankleInnerX=leg.ankleInnerX;
-      const ankleOuterX=leg.ankleOuterX;
-      if(ankleInnerX==null||ankleOuterX==null) return;
-      const ankleY=leg.ankleY!=null?leg.ankleY:shoeTop;
-      const direction=leg.direction||((ankleOuterX>=ankleInnerX)?1:-1);
-      const rawWidth=Math.abs(ankleOuterX-ankleInnerX);
-      const footWidth=leg.footWidth!=null?leg.footWidth:Math.max(rawWidth,1.8*scale);
-      const shoeBottom=ankleY+shoeHeight;
-      const footCenter=(ankleInnerX+ankleOuterX)/2;
-      const heelDepth=footWidth*0.45;
-      const outerCurve=footWidth*0.6;
-      const toeReach=footWidth*0.95;
-      const soleDip=shoeHeight*0.25;
-      const shoeGrad=ctx.createLinearGradient(footCenter, ankleY, footCenter, shoeBottom);
-      shoeGrad.addColorStop(0, shoeColors.highlight||shoeColors.base||'#666');
-      shoeGrad.addColorStop(0.6, shoeColors.base||'#444');
-      shoeGrad.addColorStop(1, shoeColors.shadow||shoeColors.trim||'#222');
-      ctx.fillStyle=shoeGrad;
-      ctx.beginPath();
-      ctx.moveTo(ankleInnerX, ankleY);
-      ctx.bezierCurveTo(ankleInnerX - direction*heelDepth*0.55, ankleY + shoeHeight*0.2, ankleInnerX - direction*heelDepth, shoeBottom - soleDip, ankleInnerX - direction*heelDepth*0.25, shoeBottom);
-      ctx.bezierCurveTo(footCenter, shoeBottom + shoeHeight*0.35, ankleOuterX + direction*toeReach, shoeBottom - shoeHeight*0.1, ankleOuterX + direction*outerCurve, ankleY + shoeHeight*0.55);
-      ctx.quadraticCurveTo(ankleOuterX + direction*footWidth*0.18, ankleY + shoeHeight*0.18, ankleOuterX, ankleY);
-      ctx.closePath();
-      ctx.fill();
-      if(shoeColors.stroke){
-        ctx.strokeStyle=shoeColors.stroke;
-        ctx.lineWidth=Math.max(1,1.2*scale);
-        ctx.stroke();
-      }
-      if(shoeColors.trim){
-        ctx.strokeStyle=shoeColors.trim;
-        ctx.lineWidth=0.75*scale;
-        ctx.beginPath();
-        ctx.moveTo(ankleInnerX - direction*heelDepth*0.2, ankleY + shoeHeight*0.35);
-        ctx.quadraticCurveTo(footCenter, ankleY + shoeHeight*0.12, ankleOuterX + direction*outerCurve*0.55, ankleY + shoeHeight*0.4);
-        ctx.stroke();
-      }
-    };
-
-    if(!leftLeg && !rightLeg){
-      fallbackShoes();
-    }else{
-      drawShoe(leftLeg);
-      drawShoe(rightLeg);
-    }
-    ctx.restore();
-
-    if(!equipment.accessory) return;
-
-    const accColors=palette.accessory||{};
-    const baseColor=accColors.base||'#f8b500';
-    const highlight=accColors.highlight||baseColor;
-    const shadow=accColors.shadow||accColors.stroke||baseColor;
-    const chainColor=accColors.chain||highlight;
-    const medallionRadius=3.4*scale;
-    const chainTop=torsoY+2.5*scale;
-    const chainBottom=torsoY+6.5*scale;
-    ctx.save();
-    ctx.strokeStyle=chainColor;
-    ctx.lineWidth=Math.max(0.9*scale,0.7);
-    ctx.beginPath();
-    ctx.moveTo(centerX-6*scale, chainTop);
-    ctx.quadraticCurveTo(centerX, chainBottom-2*scale, centerX+6*scale, chainTop);
-    ctx.stroke();
-
-    const radial=ctx.createRadialGradient(centerX, chainBottom, medallionRadius*0.2, centerX, chainBottom, medallionRadius);
-    radial.addColorStop(0, highlight);
-    radial.addColorStop(0.7, baseColor);
-    radial.addColorStop(1, shadow);
-    ctx.fillStyle=radial;
-    ctx.beginPath();
-    ctx.arc(centerX, chainBottom, medallionRadius, 0, Math.PI*2);
-    ctx.fill();
-
-    if(accColors.stroke){
-      ctx.strokeStyle=accColors.stroke;
-      ctx.lineWidth=Math.max(0.9*scale,0.6);
-      ctx.stroke();
-    }
-    ctx.restore();
-  }
-
   function drawCharacter(ctx, character, options){
     if(!ctx || !hasHelpers) return null;
     const opts = Object.assign({
@@ -943,17 +601,41 @@
       arms:{left:leftArmProfile, right:rightArmProfile}
     };
 
-    drawAccessories(ctx, palette, metrics, scale, equip, 'back');
+    if(renderEquipmentLayers){
+      renderEquipmentLayers(ctx, metrics, equip, appearance, {
+        phase: 'back',
+        palette,
+        scale,
+        gender: genderKey,
+        shadeColor,
+        options: opts
+      });
+    }
     ctx.save();
     drawHair(ctx, appearance.style, appearance.hair, headCx, hairTop, faceScale, 'back');
     ctx.restore();
     drawHead(ctx, headCx, headCy, headRadius, appearance.skin);
-    drawLowerOutfit(ctx, palette, metrics, scale, {equip, gender:genderKey});
-    drawUpperOutfit(ctx, palette, metrics, scale, {equip, gender:genderKey});
+    let deferredFrontLayers = null;
+    if(renderEquipmentLayers){
+      deferredFrontLayers = renderEquipmentLayers(ctx, metrics, equip, appearance, {
+        phase: 'front',
+        palette,
+        scale,
+        gender: genderKey,
+        shadeColor,
+        options: opts
+      });
+    }
     ctx.save();
     drawHair(ctx, appearance.style, appearance.hair, headCx, hairTop, faceScale, 'front');
     ctx.restore();
-    drawAccessories(ctx, palette, metrics, scale, equip, 'front');
+    if(deferredFrontLayers && Array.isArray(deferredFrontLayers.deferred)){
+      deferredFrontLayers.deferred.forEach(fn=>{
+        if(typeof fn === 'function'){
+          fn();
+        }
+      });
+    }
     drawExpression(ctx, appearance.emotion, headCx, headCy, appearance.eyes, faceScale);
 
     if(equip.head){

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/outfitLayers.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/outfitLayers.js
@@ -1,0 +1,520 @@
+(function(global){
+  if(!global) return;
+
+  function toNumber(value, fallback){
+    return (typeof value === 'number' && Number.isFinite(value)) ? value : fallback;
+  }
+
+  function getVariant(options, slot){
+    if(!options) return null;
+    const variants = options.styleVariants || options.layerVariants || {};
+    return variants[slot] || null;
+  }
+
+  function variantValue(variant, key, fallback, scale){
+    if(!variant || !Object.prototype.hasOwnProperty.call(variant, key)){
+      return fallback;
+    }
+    const raw = variant[key];
+    if(typeof raw === 'number'){
+      return raw * scale;
+    }
+    if(typeof raw === 'function'){
+      return raw(scale, fallback);
+    }
+    if(raw && typeof raw === 'object'){
+      if(typeof raw.absolute === 'number'){
+        return raw.absolute;
+      }
+      if(typeof raw.multiplier === 'number'){
+        return raw.multiplier * scale;
+      }
+    }
+    return fallback;
+  }
+
+  function drawUpperLayer(shared){
+    const {ctx, metrics, palette, scale, equip, gender, options} = shared;
+    if(!ctx) return;
+    const {centerX, torsoY, torsoHeight} = metrics;
+    if(centerX == null || torsoY == null || torsoHeight == null) return;
+    const contour = metrics.torsoContour || {};
+    const neckBaseY = contour.neckBaseY != null ? contour.neckBaseY : torsoY;
+    const shoulderY = contour.shoulderY != null ? contour.shoulderY : torsoY + 4*scale;
+    const chestY = contour.chestY != null ? contour.chestY : torsoY + 8*scale;
+    const waistY = contour.waistY != null ? contour.waistY : torsoY + torsoHeight*0.55;
+    const hipY = (contour.hipY != null ? contour.hipY : torsoY + torsoHeight) - 1.1*scale;
+    const neckHalf = contour.neckHalf != null ? contour.neckHalf : (metrics.torsoWidth || 20*scale)/2;
+    const shoulderHalf = contour.shoulderHalf != null ? contour.shoulderHalf : neckHalf + 2*scale;
+    const chestHalf = contour.chestHalf != null ? contour.chestHalf : shoulderHalf - 0.8*scale;
+    const waistHalf = contour.waistHalf != null ? contour.waistHalf : chestHalf - 2.4*scale;
+    const hipHalf = contour.hipHalf != null ? contour.hipHalf : waistHalf + 1.4*scale;
+    const hasEquip = !!(equip && equip.upper);
+    const colors = palette.upper || {};
+    const baseColor = colors.base || '#5c7ab2';
+    const highlight = colors.highlight || baseColor;
+    const shadow = colors.shadow || baseColor;
+    const variant = getVariant(options, 'upper');
+    const collarDrop = variantValue(variant, 'collarDrop', hasEquip ? 0.45*scale : 0.2*scale, scale);
+    const collarDip = variantValue(variant, 'collarDip', hasEquip ? 1.8*scale : 1.1*scale, scale);
+    const outerOffset = variantValue(variant, 'outerOffset', hasEquip ? 1.6*scale : 0.9*scale, scale);
+    const hemSpread = variantValue(variant, 'hemSpread', hasEquip ? 1.8*scale : 1.2*scale, scale);
+    const waistEase = variantValue(variant, 'waistEase', hasEquip ? 0.6*scale : (gender === 'female' ? 0.4*scale : 0.1*scale), scale);
+    ctx.save();
+    const grad = ctx.createLinearGradient(centerX, neckBaseY - collarDip, centerX, hipY + 3*scale);
+    grad.addColorStop(0, highlight);
+    grad.addColorStop(0.55, baseColor);
+    grad.addColorStop(1, shadow);
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.moveTo(centerX - neckHalf - outerOffset*0.4, neckBaseY - collarDrop);
+    ctx.quadraticCurveTo(centerX - neckHalf*0.6, neckBaseY - collarDrop - collarDip, centerX, neckBaseY - collarDrop - collarDip*0.75);
+    ctx.quadraticCurveTo(centerX + neckHalf*0.6, neckBaseY - collarDrop - collarDip, centerX + neckHalf + outerOffset*0.4, neckBaseY - collarDrop);
+    ctx.quadraticCurveTo(centerX + shoulderHalf + outerOffset, shoulderY, centerX + chestHalf + outerOffset*0.5, chestY);
+    ctx.quadraticCurveTo(centerX + waistHalf + waistEase, waistY + 0.4*scale, centerX + hipHalf + hemSpread, hipY);
+    ctx.quadraticCurveTo(centerX, hipY + 0.8*scale, centerX - hipHalf - hemSpread, hipY);
+    ctx.quadraticCurveTo(centerX - (waistHalf + waistEase), waistY + 0.4*scale, centerX - (chestHalf + outerOffset*0.5), chestY);
+    ctx.quadraticCurveTo(centerX - (shoulderHalf + outerOffset), shoulderY, centerX - neckHalf - outerOffset*0.4, neckBaseY - collarDrop);
+    ctx.closePath();
+    ctx.fill();
+
+    if(colors.stroke){
+      const strokeWidth = Math.max(1, variantValue(variant, 'strokeWidth', 1.25*scale, scale));
+      ctx.strokeStyle = colors.stroke;
+      ctx.lineWidth = strokeWidth;
+      ctx.stroke();
+    }
+
+    const trimEnabled = !variant || variant.disableTrim !== true;
+    if(colors.trim && trimEnabled){
+      const beltHeight = Math.max(scale, variantValue(variant, 'beltHeight', 1.6*scale, scale));
+      const beltYOffset = variantValue(variant, 'beltYOffset', 0.6*scale, scale);
+      const beltY = waistY + beltYOffset;
+      ctx.fillStyle = colors.trim;
+      ctx.beginPath();
+      ctx.moveTo(centerX - waistHalf - 0.8*scale, beltY);
+      ctx.quadraticCurveTo(centerX, beltY + 0.4*scale, centerX + waistHalf + 0.8*scale, beltY);
+      ctx.lineTo(centerX + waistHalf + 0.7*scale, beltY + beltHeight);
+      ctx.quadraticCurveTo(centerX, beltY + beltHeight + 0.35*scale, centerX - waistHalf - 0.7*scale, beltY + beltHeight);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    const highlightEnabled = !variant || variant.disableHighlight !== true;
+    if(colors.highlight && hasEquip && highlightEnabled){
+      const seamOffset = variantValue(variant, 'highlightOffset', 0, scale);
+      const highlightWidth = Math.max(0.6*scale, variantValue(variant, 'highlightWidth', 0.85*scale, scale));
+      ctx.strokeStyle = colors.highlight;
+      ctx.lineWidth = highlightWidth;
+      ctx.beginPath();
+      ctx.moveTo(centerX + seamOffset, neckBaseY - collarDrop - collarDip*0.5);
+      ctx.quadraticCurveTo(centerX + seamOffset, waistY + 0.6*scale, centerX + seamOffset, hipY - 0.3*scale);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  function drawLowerLayer(shared){
+    const {ctx, metrics, palette, scale, equip, gender, options} = shared;
+    if(!ctx) return;
+    const {hipY, kneeY, shoeTop, centerX} = metrics;
+    if(hipY == null || kneeY == null || shoeTop == null || centerX == null) return;
+    const contour = metrics.torsoContour || {};
+    const legProfiles = metrics.legs || {};
+    const leftLeg = legProfiles.left;
+    const rightLeg = legProfiles.right;
+    const hasEquip = !!(equip && equip.lower);
+    const colors = palette.lower || {};
+    const baseColor = colors.base || '#4a668d';
+    const highlight = colors.highlight || baseColor;
+    const shadow = colors.shadow || baseColor;
+    const waistY = contour.waistY != null ? contour.waistY : (hipY - 6*scale);
+    const hipTop = (contour.hipY != null ? contour.hipY : hipY) - 0.4*scale;
+    const variant = getVariant(options, 'lower');
+    ctx.save();
+    const grad = ctx.createLinearGradient(centerX, waistY, centerX, shoeTop);
+    grad.addColorStop(0, highlight);
+    grad.addColorStop(0.65, baseColor);
+    grad.addColorStop(1, shadow);
+
+    const fallback = ()=>{
+      ctx.fillStyle = grad;
+      const torsoX = metrics.torsoX != null ? metrics.torsoX : (centerX - (metrics.torsoWidth || 20*scale)/2);
+      const torsoWidth = metrics.torsoWidth || 20*scale;
+      const legInset = variantValue(variant, 'fallbackInset', 3*scale, scale);
+      const crotchWidth = variantValue(variant, 'fallbackCrotch', 4*scale, scale);
+      const legWidth = (torsoWidth - crotchWidth)/2;
+      ctx.beginPath();
+      ctx.moveTo(torsoX + legInset, hipY);
+      ctx.quadraticCurveTo(torsoX + legInset + legWidth*0.2, kneeY, torsoX + 4*scale, shoeTop);
+      ctx.lineTo(torsoX + 12*scale, shoeTop);
+      ctx.quadraticCurveTo(torsoX + legInset + legWidth*0.8, kneeY - 2*scale, centerX - crotchWidth/2, hipY + 2*scale);
+      ctx.lineTo(centerX - crotchWidth/2, hipY);
+      ctx.closePath();
+      ctx.fill();
+      ctx.beginPath();
+      ctx.moveTo(centerX + crotchWidth/2, hipY);
+      ctx.lineTo(centerX + crotchWidth/2, hipY + 2*scale);
+      ctx.quadraticCurveTo(torsoX + torsoWidth - legInset - legWidth*0.8, kneeY - 2*scale, torsoX + torsoWidth - 4*scale, shoeTop);
+      ctx.lineTo(torsoX + torsoWidth - 4*scale, shoeTop);
+      ctx.quadraticCurveTo(torsoX + torsoWidth - legInset - legWidth*0.2, kneeY, torsoX + torsoWidth - legInset, hipY);
+      ctx.closePath();
+      ctx.fill();
+    };
+
+    if(!leftLeg || !rightLeg){
+      fallback();
+      ctx.restore();
+      return;
+    }
+
+    ctx.fillStyle = grad;
+
+    const allowSkirt = !hasEquip && gender === 'female' && (!variant || variant.forceSplit !== true);
+    if(allowSkirt){
+      const flare = variantValue(variant, 'skirtFlare', 3.2*scale, scale);
+      const hemDrop = variantValue(variant, 'skirtHem', 6.2*scale, scale);
+      ctx.beginPath();
+      ctx.moveTo(leftLeg.hipOuterX - 1.1*scale, hipTop);
+      ctx.quadraticCurveTo(centerX, hipTop + 1.7*scale, rightLeg.hipOuterX + 1.1*scale, hipTop);
+      ctx.quadraticCurveTo(rightLeg.ankleOuterX + flare, shoeTop + hemDrop*0.56, centerX, shoeTop + hemDrop);
+      ctx.quadraticCurveTo(leftLeg.ankleOuterX - flare, shoeTop + hemDrop*0.56, leftLeg.hipOuterX - 1.1*scale, hipTop);
+      ctx.closePath();
+      ctx.fill();
+      if(colors.stroke){
+        const strokeWidth = Math.max(1, variantValue(variant, 'skirtStrokeWidth', 1.1*scale, scale));
+        ctx.strokeStyle = colors.stroke;
+        ctx.lineWidth = strokeWidth;
+        ctx.stroke();
+      }
+      if(colors.trim && (!variant || variant.disableTrim !== true)){
+        ctx.strokeStyle = colors.trim;
+        ctx.lineWidth = Math.max(0.6*scale, variantValue(variant, 'skirtTrimWidth', 0.85*scale, scale));
+        ctx.beginPath();
+        ctx.moveTo(leftLeg.hipOuterX - 0.8*scale, hipTop + 0.6*scale);
+        ctx.quadraticCurveTo(centerX, hipTop + 2.2*scale, rightLeg.hipOuterX + 0.8*scale, hipTop + 0.6*scale);
+        ctx.stroke();
+      }
+      ctx.restore();
+      return;
+    }
+
+    const outerInset = variantValue(variant, 'outerInset', hasEquip ? 1.3*scale : 0.8*scale, scale);
+    const seamInset = variantValue(variant, 'seamInset', hasEquip ? 1.1*scale : 0.7*scale, scale);
+    ctx.beginPath();
+    ctx.moveTo(leftLeg.hipOuterX - outerInset, hipTop);
+    ctx.quadraticCurveTo(leftLeg.kneeOuterX - outerInset*0.4, kneeY + 0.2*scale, leftLeg.ankleOuterX - outerInset*0.1, shoeTop);
+    ctx.lineTo(leftLeg.ankleInnerX + seamInset*0.4, shoeTop);
+    ctx.quadraticCurveTo(leftLeg.kneeInnerX + seamInset*0.35, kneeY, centerX - seamInset*0.45, hipY - 0.2*scale);
+    ctx.quadraticCurveTo(centerX, hipY + 0.5*scale, centerX + seamInset*0.45, hipY - 0.2*scale);
+    ctx.quadraticCurveTo(rightLeg.kneeInnerX - seamInset*0.35, kneeY, rightLeg.ankleInnerX - seamInset*0.4, shoeTop);
+    ctx.lineTo(rightLeg.ankleOuterX + outerInset*0.1, shoeTop);
+    ctx.quadraticCurveTo(rightLeg.kneeOuterX + outerInset*0.4, kneeY + 0.2*scale, rightLeg.hipOuterX + outerInset, hipTop);
+    ctx.quadraticCurveTo(centerX, hipTop + 1.4*scale, leftLeg.hipOuterX - outerInset, hipTop);
+    ctx.closePath();
+    ctx.fill();
+
+    if(colors.stroke){
+      ctx.strokeStyle = colors.stroke;
+      ctx.lineWidth = Math.max(1, variantValue(variant, 'strokeWidth', 1.05*scale, scale));
+      ctx.stroke();
+    }
+
+    if(colors.trim && (!variant || variant.disableTrim !== true)){
+      ctx.strokeStyle = colors.trim;
+      ctx.lineWidth = Math.max(0.6*scale, variantValue(variant, 'trimWidth', 0.8*scale, scale));
+      ctx.beginPath();
+      const seamCurve = variantValue(variant, 'seamCurve', 0.8*scale, scale);
+      ctx.moveTo(centerX, hipTop + 0.4*scale);
+      ctx.quadraticCurveTo(centerX, hipY + seamCurve, centerX, shoeTop - 0.8*scale);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  function drawCloakBack(shared){
+    const {ctx, metrics, palette, scale, options} = shared;
+    if(!ctx) return;
+    const {torsoX, torsoY, torsoWidth, footBaseline, centerX, headCy, headRadius} = metrics;
+    if(torsoX == null || torsoY == null || torsoWidth == null || footBaseline == null || centerX == null || headCy == null || headRadius == null) return;
+    const colors = palette.cloak || {};
+    const variant = getVariant(options, 'cloak');
+    ctx.save();
+    const grad = ctx.createLinearGradient(centerX, torsoY, centerX, footBaseline);
+    grad.addColorStop(0, colors.highlight || colors.base || '#0f3460');
+    grad.addColorStop(0.7, colors.base || '#0f3460');
+    grad.addColorStop(1, colors.shadow || colors.edge || '#071f2a');
+    ctx.fillStyle = grad;
+    const shoulderDrop = variantValue(variant, 'shoulderDrop', 2*scale, scale);
+    const sideSpread = variantValue(variant, 'sideSpread', 5*scale, scale);
+    const flare = variantValue(variant, 'flare', 6*scale, scale);
+    const hemRise = variantValue(variant, 'hemRise', -2*scale, scale);
+    ctx.beginPath();
+    ctx.moveTo(torsoX - sideSpread, torsoY + shoulderDrop);
+    ctx.quadraticCurveTo(centerX - flare, headCy + headRadius*0.6, torsoX - sideSpread + 1*scale, footBaseline + hemRise);
+    ctx.quadraticCurveTo(centerX, footBaseline + (hemRise >= 0 ? hemRise : 6*scale), torsoX + torsoWidth + sideSpread - 1*scale, footBaseline + hemRise);
+    ctx.quadraticCurveTo(centerX + flare, headCy + headRadius*0.6, torsoX + torsoWidth + sideSpread, torsoY + shoulderDrop);
+    ctx.closePath();
+    ctx.fill();
+    const edgeColor = colors.edge || colors.stroke;
+    if(edgeColor){
+      ctx.strokeStyle = edgeColor;
+      ctx.lineWidth = Math.max(1, variantValue(variant, 'edgeWidth', 1.4*scale, scale));
+      ctx.stroke();
+    }
+    if(colors.lining && (!variant || variant.disableLining !== true)){
+      ctx.strokeStyle = colors.lining;
+      ctx.lineWidth = Math.max(0.6*scale, variantValue(variant, 'liningWidth', 0.9*scale, scale));
+      ctx.beginPath();
+      const liningOffset = variantValue(variant, 'liningOffset', 2*scale, scale);
+      ctx.moveTo(torsoX - sideSpread + liningOffset, torsoY + shoulderDrop + liningOffset);
+      ctx.quadraticCurveTo(centerX - flare*0.8, headCy + headRadius*0.7, torsoX - sideSpread + liningOffset + 1*scale, footBaseline + hemRise - 1*scale);
+      ctx.moveTo(torsoX + torsoWidth + sideSpread - liningOffset, torsoY + shoulderDrop + liningOffset);
+      ctx.quadraticCurveTo(centerX + flare*0.8, headCy + headRadius*0.7, torsoX + torsoWidth + sideSpread - liningOffset - 1*scale, footBaseline + hemRise - 1*scale);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  function drawShoes(shared){
+    const {ctx, metrics, palette, scale, options} = shared;
+    if(!ctx) return;
+    const {torsoX, torsoWidth, shoeTop, shoeHeight, centerX} = metrics;
+    if(torsoX == null || torsoWidth == null || shoeTop == null || shoeHeight == null || centerX == null) return;
+    const legs = metrics.legs || {};
+    const leftLeg = legs.left;
+    const rightLeg = legs.right;
+    const colors = palette.shoes || {};
+    const variant = getVariant(options, 'shoes');
+    ctx.save();
+    const fallbackShoes = ()=>{
+      const shoeGrad = ctx.createLinearGradient(centerX, shoeTop, centerX, shoeTop + shoeHeight);
+      shoeGrad.addColorStop(0, colors.highlight || colors.base || '#666');
+      shoeGrad.addColorStop(0.6, colors.base || '#444');
+      shoeGrad.addColorStop(1, colors.shadow || colors.trim || '#222');
+      ctx.fillStyle = shoeGrad;
+      const toeOffset = variantValue(variant, 'toeOffset', 3*scale, scale);
+      const rightToe = torsoX + torsoWidth + variantValue(variant, 'toeSpacing', 5*scale, scale);
+      const leftToe = torsoX + toeOffset;
+      const flare = variantValue(variant, 'toeFlare', 2*scale, scale);
+      ctx.beginPath();
+      ctx.moveTo(leftToe, shoeTop);
+      ctx.quadraticCurveTo(leftToe - flare, shoeTop + shoeHeight*0.7, leftToe + flare, shoeTop + shoeHeight);
+      ctx.lineTo(rightToe - flare, shoeTop + shoeHeight);
+      ctx.quadraticCurveTo(rightToe + flare, shoeTop + shoeHeight*0.7, rightToe - flare, shoeTop);
+      ctx.closePath();
+      ctx.fill();
+      if(colors.stroke){
+        ctx.strokeStyle = colors.stroke;
+        ctx.lineWidth = Math.max(1, variantValue(variant, 'strokeWidth', 1.2*scale, scale));
+        ctx.stroke();
+      }
+      if(colors.trim && (!variant || variant.disableTrim !== true)){
+        ctx.strokeStyle = colors.trim;
+        ctx.lineWidth = Math.max(0.5*scale, variantValue(variant, 'trimWidth', 0.8*scale, scale));
+        ctx.beginPath();
+        ctx.moveTo(leftToe + 4*scale, shoeTop + shoeHeight*0.35);
+        ctx.quadraticCurveTo(centerX, shoeTop + shoeHeight*0.15, rightToe - 6*scale, shoeTop + shoeHeight*0.35);
+        ctx.stroke();
+      }
+    };
+
+    const drawShoe = (leg)=>{
+      if(!leg) return;
+      const ankleInnerX = leg.ankleInnerX;
+      const ankleOuterX = leg.ankleOuterX;
+      if(ankleInnerX == null || ankleOuterX == null) return;
+      const ankleY = leg.ankleY != null ? leg.ankleY : shoeTop;
+      const direction = leg.direction || ((ankleOuterX >= ankleInnerX) ? 1 : -1);
+      const rawWidth = Math.abs(ankleOuterX - ankleInnerX);
+      const footWidth = leg.footWidth != null ? leg.footWidth : Math.max(rawWidth, 1.8*scale);
+      const shoeBottom = ankleY + shoeHeight;
+      const footCenter = (ankleInnerX + ankleOuterX) / 2;
+      const heelDepth = variantValue(variant, 'heelDepth', footWidth*0.45, scale);
+      const outerCurve = variantValue(variant, 'outerCurve', footWidth*0.6, scale);
+      const toeReach = variantValue(variant, 'toeReach', footWidth*0.95, scale);
+      const soleDip = variantValue(variant, 'soleDip', shoeHeight*0.25, scale);
+      const shoeGrad = ctx.createLinearGradient(footCenter, ankleY, footCenter, shoeBottom);
+      shoeGrad.addColorStop(0, colors.highlight || colors.base || '#666');
+      shoeGrad.addColorStop(0.6, colors.base || '#444');
+      shoeGrad.addColorStop(1, colors.shadow || colors.trim || '#222');
+      ctx.fillStyle = shoeGrad;
+      ctx.beginPath();
+      ctx.moveTo(ankleInnerX, ankleY);
+      ctx.bezierCurveTo(ankleInnerX - direction*heelDepth*0.55, ankleY + shoeHeight*0.2, ankleInnerX - direction*heelDepth, shoeBottom - soleDip, ankleInnerX - direction*heelDepth*0.25, shoeBottom);
+      ctx.bezierCurveTo(footCenter, shoeBottom + shoeHeight*0.35, ankleOuterX + direction*toeReach, shoeBottom - shoeHeight*0.1, ankleOuterX + direction*outerCurve, ankleY + shoeHeight*0.55);
+      ctx.quadraticCurveTo(ankleOuterX + direction*footWidth*0.18, ankleY + shoeHeight*0.18, ankleOuterX, ankleY);
+      ctx.closePath();
+      ctx.fill();
+      if(colors.stroke){
+        ctx.strokeStyle = colors.stroke;
+        ctx.lineWidth = Math.max(1, variantValue(variant, 'strokeWidth', 1.2*scale, scale));
+        ctx.stroke();
+      }
+      if(colors.trim && (!variant || variant.disableTrim !== true)){
+        ctx.strokeStyle = colors.trim;
+        ctx.lineWidth = Math.max(0.45*scale, variantValue(variant, 'trimWidth', 0.75*scale, scale));
+        ctx.beginPath();
+        ctx.moveTo(ankleInnerX - direction*heelDepth*0.2, ankleY + shoeHeight*0.35);
+        ctx.quadraticCurveTo(footCenter, ankleY + shoeHeight*0.12, ankleOuterX + direction*outerCurve*0.55, ankleY + shoeHeight*0.4);
+        ctx.stroke();
+      }
+    };
+
+    if(!leftLeg && !rightLeg){
+      fallbackShoes();
+    }else{
+      drawShoe(leftLeg);
+      drawShoe(rightLeg);
+    }
+    ctx.restore();
+  }
+
+  function drawAccessory(shared){
+    const {ctx, metrics, palette, scale, equip, options} = shared;
+    if(!ctx || !equip || !equip.accessory) return;
+    const {torsoY, centerX} = metrics;
+    if(torsoY == null || centerX == null) return;
+    const colors = palette.accessory || {};
+    const baseColor = colors.base || '#f8b500';
+    const highlight = colors.highlight || baseColor;
+    const shadow = colors.shadow || colors.stroke || baseColor;
+    const chainColor = colors.chain || highlight;
+    const variant = getVariant(options, 'accessory');
+    const chainTop = torsoY + variantValue(variant, 'chainTopOffset', 2.5*scale, scale);
+    const chainBottom = torsoY + variantValue(variant, 'chainBottomOffset', 6.5*scale, scale);
+    const spread = variantValue(variant, 'chainSpread', 6*scale, scale);
+    const medallionRadius = Math.max(scale, variantValue(variant, 'medallionRadius', 3.4*scale, scale));
+    ctx.save();
+    ctx.strokeStyle = chainColor;
+    ctx.lineWidth = Math.max(0.6*scale, variantValue(variant, 'chainWidth', 0.9*scale, scale));
+    ctx.beginPath();
+    ctx.moveTo(centerX - spread, chainTop);
+    ctx.quadraticCurveTo(centerX, chainBottom - 2*scale, centerX + spread, chainTop);
+    ctx.stroke();
+
+    const radial = ctx.createRadialGradient(centerX, chainBottom, medallionRadius*0.2, centerX, chainBottom, medallionRadius);
+    radial.addColorStop(0, highlight);
+    radial.addColorStop(0.7, baseColor);
+    radial.addColorStop(1, shadow);
+    ctx.fillStyle = radial;
+    ctx.beginPath();
+    ctx.arc(centerX, chainBottom, medallionRadius, 0, Math.PI*2);
+    ctx.fill();
+
+    if(colors.stroke){
+      ctx.strokeStyle = colors.stroke;
+      ctx.lineWidth = Math.max(0.5*scale, variantValue(variant, 'medallionStrokeWidth', 0.9*scale, scale));
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  const DEFAULT_LAYER_CONFIG = {
+    back: [
+      {
+        id: 'cloak-back',
+        slot: 'cloak',
+        order: 10,
+        placement: 'underHair',
+        condition: ({equip}) => !!(equip && equip.cloak),
+        draw: drawCloakBack
+      }
+    ],
+    front: [
+      {
+        id: 'lower-base',
+        slot: 'lower',
+        order: 10,
+        placement: 'underHair',
+        condition: () => true,
+        draw: drawLowerLayer
+      },
+      {
+        id: 'upper-base',
+        slot: 'upper',
+        order: 20,
+        placement: 'underHair',
+        condition: () => true,
+        draw: drawUpperLayer
+      },
+      {
+        id: 'shoe-base',
+        slot: 'shoes',
+        order: 30,
+        placement: 'underHair',
+        condition: () => true,
+        draw: drawShoes
+      },
+      {
+        id: 'necklace',
+        slot: 'accessory',
+        order: 40,
+        placement: 'overHair',
+        condition: ({equip}) => !!(equip && equip.accessory),
+        draw: drawAccessory
+      }
+    ]
+  };
+
+  function normalizeLayers(config, phase){
+    const layers = (config && config[phase]) ? config[phase] : [];
+    return layers.slice().sort((a, b)=>toNumber(a.order, 0) - toNumber(b.order, 0));
+  }
+
+  function renderEquipmentLayers(ctx, metrics, equip, appearance, options){
+    if(!ctx) return null;
+    const opts = Object.assign({phase: 'front'}, options || {});
+    const phase = opts.phase || 'front';
+    const palette = opts.palette || {};
+    const config = opts.layerConfig || DEFAULT_LAYER_CONFIG;
+    const overrides = opts.layerOverrides || {};
+    const scale = toNumber(opts.scale, 1);
+    const shared = {
+      ctx,
+      metrics: metrics || {},
+      equip: equip || {},
+      appearance: appearance || {},
+      palette,
+      scale,
+      gender: opts.gender || 'other',
+      options: opts.options || opts,
+      shadeColor: typeof opts.shadeColor === 'function' ? opts.shadeColor : null
+    };
+    const layers = normalizeLayers(config, phase);
+    const deferred = [];
+    layers.forEach(layer => {
+      const layerId = layer.id || `${phase}-${layer.slot || 'layer'}`;
+      const override = overrides[layerId] || (layer.slot ? overrides[layer.slot] : null) || null;
+      if(override && override.enabled === false){
+        return;
+      }
+      const condition = (override && typeof override.condition === 'function') ? override.condition : layer.condition;
+      if(typeof condition === 'function' && condition(shared) === false){
+        return;
+      }
+      const draw = (override && typeof override.draw === 'function') ? override.draw : layer.draw;
+      if(typeof draw !== 'function'){
+        return;
+      }
+      const placement = (override && override.placement) || layer.placement || 'underHair';
+      const runner = ()=>draw(shared);
+      if(placement === 'overHair'){
+        deferred.push(runner);
+      }else{
+        runner();
+      }
+    });
+    if(deferred.length){
+      return {deferred};
+    }
+    return null;
+  }
+
+  global.AvatarOutfitLayers = Object.assign({}, global.AvatarOutfitLayers, {
+    renderEquipmentLayers,
+    DEFAULT_LAYER_CONFIG
+  });
+})(typeof window !== 'undefined' ? window : this);

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -104,6 +104,7 @@
 </div>
 
 <script src="/static/js/avatar_drawing.js"></script>
+<script src="/static/js/outfitLayers.js"></script>
 <script src="/static/js/characterRenderer.js"></script>
 <script src="/static/js/location.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- introduce a dedicated outfitLayers module that defines the avatar equipment layers as data and renders them with palette-aware helpers
- update the character renderer to rely on the new layered equipment system and remove the legacy drawUpper/Lower/Accessories helpers
- load the new script on the location page so stage and preview canvases use the shared layer pipeline

## Testing
- python server.py (launches local app for manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d91750365c832a8c12d856ba00e29e