### PR TITLE
Stop auto-equipping default clothing

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/main.py
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/main.py
@@ -40,8 +40,8 @@ STATE: Dict[str, Any] = {
 
 DEFAULT_INV = [
     {"id": 1001, "name": "Простая шляпа", "type": "head", "equipped": False},
-    {"id": 1002, "name": "Простая рубашка", "type": "upper", "equipped": True},
-    {"id": 1003, "name": "Простые штаны", "type": "lower", "equipped": True},
+    {"id": 1002, "name": "Простая рубашка", "type": "upper", "equipped": False},
+    {"id": 1003, "name": "Простые штаны", "type": "lower", "equipped": False},
     {"id": 1004, "name": "Простые ботинки", "type": "shoes", "equipped": False},
 ]
 


### PR DESCRIPTION
## Summary
- mark default upper and lower clothing as unequipped so new users don't auto-equip starter gear

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9200373d0832a93b2e85111f64788