### PR TITLE
Reorder profile buttons in location header

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -10,8 +10,8 @@
 <header class="topbar">
   <div class="brand">Коллективное Предсказание</div>
   <div class="me">
-    <button class="ghost" id="btn-character">Персонаж</button>
     <button class="ghost" id="btn-shop">Магазин</button>
+    <button class="ghost" id="btn-character">Персонаж</button>
     <span id="u-gender" class="gender-ico">⚧</span>
     <span id="u-name">{{ username }}</span>
   </div>


### PR DESCRIPTION
## Summary
- reorder the shop and character buttons in the location header so the shop button comes first
- verified the existing JavaScript continues to bind click handlers to the same button IDs

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d93383be0c832a8096040d591bacd5