### PR TITLE
Add profile badge button to location header

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -3,9 +3,15 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 
 .topbar{display:flex;justify-content:space-between;align-items:center;padding:12px 16px;background:#0f172a;color:#fff;position:sticky;top:0;z-index:10}
 .brand{font-weight:800;letter-spacing:.2px}
-.me{display:flex;align-items:center;gap:10px;font-weight:700}
+.me{display:flex;align-items:center;gap:12px;font-weight:700}
 .ghost{background:transparent;border:1px solid rgba(255,255,255,.35);color:#fff;border-radius:10px;padding:6px 10px;cursor:pointer}
-.gender-ico{display:inline-grid;place-items:center;width:22px;height:22px;border-radius:50%;background:#ffd66b;border:1px solid #e8be4a;font-size:12px;color:#1f2937}
+.me .profile-btn{display:flex;align-items:center;gap:10px;padding:6px 14px;border-radius:999px;background:rgba(255,255,255,.14);border-color:rgba(255,255,255,.45);backdrop-filter:blur(6px);transition:background .12s ease,border-color .12s ease}
+.me .profile-btn:hover{background:rgba(255,255,255,.2);border-color:rgba(255,255,255,.6)}
+#u-face{display:block;width:56px;height:56px;border-radius:50%;background:rgba(255,255,255,.92);box-shadow:0 0 0 2px rgba(15,23,42,.16);flex-shrink:0}
+#btn-character #u-name{font-weight:700;white-space:nowrap;max-width:140px;overflow:hidden;text-overflow:ellipsis}
+#btn-character .gender-ico{margin-left:8px}
+.gender-ico{display:inline-grid;place-items:center;width:22px;height:22px;border-radius:50%;background:#ffd66b;border:1px solid #e8be4a;font-size:12px;color:#1f2937;flex-shrink:0}
+.me #btn-shop{padding:8px 14px;border-radius:12px}
 
 .mur-layout.vertical{display:flex;flex-direction:column;gap:16px;padding:16px;max-width:1100px;margin:0 auto}
 .stage-wrap{position:relative}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/location.js
@@ -379,6 +379,7 @@ async function persistAppearance(){
 // Stage rendering
 const stage=document.getElementById("stage"), ctx=stage.getContext("2d");
 const charCanvas=document.getElementById("char-canvas"), cctx=charCanvas.getContext("2d");
+const profileCanvas=document.getElementById("u-face"), pctx=profileCanvas?profileCanvas.getContext("2d"):null;
 let mePos={name:username,x:520,y:340,equip:{},appearance:Object.assign({}, myAppearance),gender:myGender},
     others={};
 
@@ -430,6 +431,25 @@ function drawCharPreview(){
   }
   const p={name:username,x:charCanvas.width/2,y:charCanvas.height/2+40,equip:mePos.equip,appearance:mePos.appearance,gender:mePos.gender||myGender};
   CharacterRenderer.draw(cctx, p, {scale:SCALE_PREVIEW, withName:false, preview:true});
+  drawProfileBadge();
+}
+function drawProfileBadge(){
+  if(!profileCanvas || !pctx){
+    return;
+  }
+  pctx.clearRect(0,0,profileCanvas.width,profileCanvas.height);
+  if(!characterRendererReady()){
+    return;
+  }
+  const portrait={
+    name:mePos.name,
+    x:profileCanvas.width/2,
+    y:profileCanvas.height*1.35,
+    equip:mePos.equip,
+    appearance:mePos.appearance,
+    gender:mePos.gender||myGender
+  };
+  CharacterRenderer.draw(pctx, portrait, {scale:2.45, withName:false, preview:true, shadow:false});
 }
 document.getElementById("go-left").addEventListener("click", ()=>{ mePos.x=Math.max(40, mePos.x-30); sendMove(); drawStage(); });
 document.getElementById("go-right").addEventListener("click", ()=>{ mePos.x=Math.min(stage.width-40, mePos.x+30); sendMove(); drawStage(); });
@@ -447,6 +467,7 @@ async function refreshAvatar(){
     localStorage.setItem('cp_gender', myGender);
     updateGenderBadge(myGender);
   }
+  drawProfileBadge();
   renderEmotionPanel();
   drawStage(); drawCharPreview(); sendState(); sendAppearance();
 }

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -10,10 +10,12 @@
 <header class="topbar">
   <div class="brand">Коллективное Предсказание</div>
   <div class="me">
-    <button class="ghost" id="btn-character">Персонаж</button>
+    <button class="ghost profile-btn" id="btn-character" type="button">
+      <canvas id="u-face" width="56" height="56" aria-hidden="true"></canvas>
+      <span id="u-name">{{ username }}</span>
+      <span id="u-gender" class="gender-ico">⚧</span>
+    </button>
     <button class="ghost" id="btn-shop">Магазин</button>
-    <span id="u-gender" class="gender-ico">⚧</span>
-    <span id="u-name">{{ username }}</span>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- restyle the location header to use a unified profile button with avatar canvas, name, and gender badge
- add styles for the compact profile badge and adjust spacing to align with the shop button
- render a miniature avatar badge via CharacterRenderer so the header stays in sync with the full preview

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9307f81c4832ab70afcdb5da13c42