### PR TITLE
Refine auth avatar preview with DOM-based character

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -99,6 +99,69 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .creator-right{display:flex;flex-direction:column;align-items:center;gap:12px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.2);border-radius:12px;padding:12px}
 .preview-header{align-self:stretch;display:flex;justify-content:flex-end;margin:0}
 .preview-emotion{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.25);color:#fff;font-size:13px;font-weight:600;min-height:0}
+.character-stage{width:100%;display:flex;justify-content:center;padding:4px 0 0}
+.character{--skin:#f1c7a3;--hair:#1e1e1e;--eyes:#2b4c7e;--underwear:#6aa2ff;--mouth-color:#d45a60;position:relative;width:200px;height:240px;display:flex;align-items:flex-end;justify-content:center}
+.character,.character *{transition:all .25s ease-in-out}
+.character-shadow{position:absolute;bottom:18px;width:120px;height:22px;background:rgba(8,13,35,.32);filter:blur(12px);border-radius:50%;opacity:.6}
+.character-inner{position:relative;display:flex;flex-direction:column;align-items:center;gap:12px;z-index:1;width:124px}
+.character-head{position:relative;width:86px;height:86px;background:var(--skin);border-radius:50%;box-shadow:inset 0 -6px 0 rgba(0,0,0,.08)}
+.character-face{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center}
+.character-eyebrows{position:absolute;top:18px;display:flex;justify-content:space-between;width:58px}
+.character-eyebrow{display:block;width:20px;height:6px;border-radius:999px;background:var(--hair)}
+.character-eyes{position:absolute;top:34px;display:flex;justify-content:space-between;width:54px}
+.character-eye{width:14px;height:14px;border-radius:50%;background:var(--eyes);box-shadow:0 0 0 3px rgba(255,255,255,.55)}
+.character-mouth{position:absolute;bottom:18px;width:32px;height:18px;border-radius:0 0 48px 48px;border-bottom:4px solid var(--mouth-color)}
+.character-hair{position:absolute;top:-18px;left:50%;transform:translateX(-50%);width:98px;height:74px;background:var(--hair);border-radius:60px 60px 40px 40px;z-index:3}
+.character-hair::after{content:"";position:absolute;left:50%;bottom:-16px;width:82px;height:42px;border-radius:50%;background:var(--hair);transform:translateX(-50%);opacity:.85}
+.character-hair-back{position:absolute;top:32px;left:50%;transform:translateX(-50%);width:94px;height:112px;background:var(--hair);border-radius:52px 52px 44px 44px;z-index:0;opacity:0}
+.character-body{position:relative;width:124px;height:150px;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding-top:12px}
+.character-arm{position:absolute;top:26px;width:30px;height:92px;background:var(--skin);border-radius:999px;box-shadow:inset 0 -10px 0 rgba(0,0,0,.08)}
+.character-arm.left{left:0;transform:rotate(8deg)}
+.character-arm.right{right:0;transform:rotate(-8deg)}
+.character-torso{position:relative;width:90px;height:96px;background:var(--skin);border-radius:42px 42px 30px 30px;display:flex;align-items:flex-end;justify-content:center;z-index:1}
+.character-underwear{width:86px;height:36px;background:var(--underwear);border-radius:30px 30px 16px 16px;margin-bottom:-6px;box-shadow:0 4px 0 rgba(0,0,0,.12) inset}
+.character-leg{position:absolute;bottom:-80px;width:36px;height:92px;background:var(--skin);border-radius:28px;box-shadow:inset 0 -12px 0 rgba(0,0,0,.08)}
+.character-leg.left{left:26px}
+.character-leg.right{right:26px}
+.character::after{content:"";position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:64px;height:10px;background:rgba(255,255,255,.28);border-radius:999px;opacity:.5}
+.character[data-gender="female"] .character-torso{border-radius:46px 46px 32px 32px}
+.character[data-gender="female"] .character-underwear{width:84px}
+.character[data-emotion="neutral"] .character-mouth{height:6px;border-radius:999px;border-bottom:3px solid var(--mouth-color)}
+.character[data-emotion="frown"] .character-mouth{height:10px;border-bottom:none;border-top:4px solid var(--mouth-color);border-radius:999px;bottom:24px}
+.character[data-emotion="frown"] .character-eyebrow.left{transform:rotate(16deg) translateY(4px)}
+.character[data-emotion="frown"] .character-eyebrow.right{transform:rotate(-16deg) translateY(4px)}
+.character[data-emotion="surprised"] .character-mouth{width:16px;height:20px;border-radius:999px;border:none;background:var(--mouth-color);bottom:22px}
+.character[data-emotion="surprised"] .character-eyes .character-eye{width:16px;height:16px}
+.character[data-emotion="surprised"] .character-eyebrow{transform:translateY(-4px)}
+.character[data-emotion="sleepy"] .character-eye{height:6px;border-radius:999px;box-shadow:none}
+.character[data-emotion="sleepy"] .character-mouth{height:6px;width:24px;border-bottom:2px solid var(--mouth-color);bottom:20px}
+.character[data-emotion="sleepy"] .character-eyebrow.left{transform:rotate(-12deg)}
+.character[data-emotion="sleepy"] .character-eyebrow.right{transform:rotate(12deg)}
+.character[data-style="buzz"] .character-hair{height:42px;top:-6px;border-radius:50%}
+.character[data-style="buzz"] .character-hair::after{opacity:0}
+.character[data-style="fade"] .character-hair{height:58px;top:-12px;border-radius:62px 62px 30px 30px}
+.character[data-style="fade"] .character-hair::after{opacity:.6;filter:brightness(.9)}
+.character[data-style="undercut"] .character-hair{border-radius:60px 60px 16px 16px;height:64px}
+.character[data-style="undercut"] .character-hair::after{bottom:-8px;width:74px;height:28px;border-radius:16px 16px 10px 10px}
+.character[data-style="mohawk"] .character-hair{width:40px;height:88px;border-radius:30px;top:-28px}
+.character[data-style="mohawk"] .character-hair::after{display:none}
+.character[data-style="curly"] .character-hair{height:86px;border-radius:46px 46px 40px 40px;background:radial-gradient(circle at 20% 30%,rgba(255,255,255,.15) 0 16%,transparent 17%),radial-gradient(circle at 80% 40%,rgba(255,255,255,.15) 0 18%,transparent 19%),var(--hair)}
+.character[data-style="curly"] .character-hair::after{opacity:0}
+.character[data-style="afro"] .character-hair{width:110px;height:110px;top:-46px;border-radius:50%}
+.character[data-style="afro"] .character-hair::after{display:none}
+.character[data-style="afro"] .character-hair-back{opacity:1;width:120px;height:120px;top:-10px;border-radius:50%}
+.character[data-style="ponytail"] .character-hair-back{opacity:1;height:140px;top:26px;border-radius:50px}
+.character[data-style="ponytail"] .character-hair-back::after{content:"";position:absolute;bottom:14px;left:50%;transform:translateX(-50%);width:34px;height:70px;background:var(--hair);border-radius:24px}
+.character[data-style="pixie"] .character-hair{height:68px;border-radius:70px 58px 30px 20px}
+.character[data-style="bob"] .character-hair{height:96px;top:-24px;border-radius:70px 70px 26px 26px}
+.character[data-style="bob"] .character-hair::after{bottom:-6px;width:100px;height:36px;border-radius:30px}
+.character[data-style="long"] .character-hair-back{opacity:1;height:160px;top:18px;border-radius:58px}
+.character[data-style="long"] .character-hair{height:96px;top:-26px;border-radius:70px 70px 40px 40px}
+.character[data-style="bun"] .character-hair-back{opacity:1;height:140px;top:18px;border-radius:60px}
+.character[data-style="bun"] .character-hair-back::after{content:"";position:absolute;top:-22px;left:50%;transform:translateX(-50%);width:56px;height:56px;background:var(--hair);border-radius:50%}
+.character[data-style="braids"] .character-hair-back{opacity:1;height:150px;top:18px;border-radius:60px}
+.character[data-style="braids"] .character-hair-back::after{content:"";position:absolute;bottom:10px;left:50%;transform:translateX(-50%);width:18px;height:84px;background:linear-gradient(180deg,var(--hair) 0%,var(--hair) 45%,rgba(255,255,255,.2) 46%,rgba(255,255,255,.2) 54%,var(--hair) 55%,var(--hair) 100%);border-radius:20px}
+.character .character-leg::after{content:"";position:absolute;bottom:-6px;left:50%;transform:translateX(-50%);width:42px;height:16px;background:rgba(255,255,255,.18);border-radius:999px}
 .small{font-size:12px}
 .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .grid3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/auth.html
@@ -122,7 +122,37 @@
           <div class="preview-header">
             <div id="preview-emotion" class="preview-emotion"></div>
           </div>
-          <canvas id="preview" width="260" height="260"></canvas>
+          <div class="character-stage">
+            <div id="preview" class="character male" data-style="short" data-emotion="smile">
+              <div class="character-shadow"></div>
+              <div class="character-inner">
+                <div class="character-head">
+                  <div class="character-hair-back"></div>
+                  <div class="character-face">
+                    <div class="character-eyebrows">
+                      <span class="character-eyebrow left"></span>
+                      <span class="character-eyebrow right"></span>
+                    </div>
+                    <div class="character-eyes">
+                      <span class="character-eye left"></span>
+                      <span class="character-eye right"></span>
+                    </div>
+                    <div class="character-mouth"></div>
+                  </div>
+                  <div class="character-hair"></div>
+                </div>
+                <div class="character-body">
+                  <div class="character-arm left"></div>
+                  <div class="character-arm right"></div>
+                  <div class="character-torso">
+                    <div class="character-underwear"></div>
+                  </div>
+                  <div class="character-leg left"></div>
+                  <div class="character-leg right"></div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -130,8 +160,6 @@
     <p id="err" class="error"></p>
   </div>
 
-<script src="/static/js/avatar_drawing.js"></script>
-<script src="/static/js/characterRenderer.js"></script>
 <script>
 // Helpers
 async function api(url, method="GET", body=null){
@@ -350,7 +378,7 @@ if(genderSelect){
 }
 
 // Preview drawing
-const pv=document.getElementById('preview'), pctx=pv.getContext('2d');
+const previewCharacterEl=document.getElementById('preview');
 function hairLabel(style){
   const map={short:"Короткая",fade:"Фейд",buzz:"Ёжик",undercut:"Андеркат",mohawk:"Ирокез",
              curly:"Кудри",afro:"Афро",ponytail:"Хвост",pixie:"Пикси",bob:"Каре",long:"Длинные",
@@ -358,23 +386,24 @@ function hairLabel(style){
   return map[style]||style;
 }
 function redrawPreview(){
-  const renderer = window.CharacterRenderer;
-  if(!renderer || typeof renderer.draw !== 'function'){
+  if(!previewCharacterEl){
     return;
   }
   const gender=genderValue();
-  const normalized = renderer.normalizeAppearance ? renderer.normalizeAppearance(state) : Object.assign({}, state);
-  const appearance = Object.assign({}, normalized);
-  pctx.clearRect(0,0,pv.width,pv.height);
-  const character={
-    name:'',
-    x:pv.width/2,
-    y:pv.height/2+40,
-    appearance,
-    equip:{},
-    gender
-  };
-  renderer.draw(pctx, character, {scale:3, withName:false, preview:true});
+  previewCharacterEl.dataset.gender=gender;
+  previewCharacterEl.dataset.style=state.style;
+  previewCharacterEl.dataset.emotion=state.emotion;
+  previewCharacterEl.classList.toggle('male', gender==='male');
+  previewCharacterEl.classList.toggle('female', gender==='female');
+  previewCharacterEl.classList.toggle('other', gender==='other');
+  previewCharacterEl.style.setProperty('--skin', state.skin);
+  previewCharacterEl.style.setProperty('--hair', state.hair);
+  previewCharacterEl.style.setProperty('--eyes', state.eyes);
+  const underwearColor = gender==='female' ? '#f472b6' : gender==='other' ? '#7c3aed' : '#6aa2ff';
+  const mouthColor = gender==='female' ? '#e76d7c' : gender==='other' ? '#f59e0b' : '#d45a60';
+  previewCharacterEl.style.setProperty('--underwear', underwearColor);
+  previewCharacterEl.style.setProperty('--mouth-color', mouthColor);
+  syncAppearanceStorage();
 }
 
 makeSwatches('skin-sw', SKINS, 'skin');


### PR DESCRIPTION
## Summary
- replace the canvas-based preview on the auth page with the new `.character` markup and drop unused drawing scripts
- add CSS styling to render the layered character, including hair style variants and emotion tweaks via data attributes
- update the preview logic to drive the DOM avatar by updating CSS variables and dataset flags instead of the renderer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93bfa6398832a82d93cb9a43761a2