### PR TITLE
Replace canvas avatars with DOM-rendered characters

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -9,7 +9,19 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 
 .mur-layout.vertical{display:flex;flex-direction:column;gap:16px;padding:16px;max-width:1100px;margin:0 auto}
 .stage-wrap{position:relative}
-#stage{display:block;width:100%;height:auto;background:linear-gradient(#cfe6ff,#eaf4ff);border:1px solid #d5def0;border-radius:12px;box-shadow:inset 0 -28px 0 rgba(255,255,255,.5)}
+#stage{position:relative;display:block;width:100%;height:460px;background:linear-gradient(#cfe6ff,#eaf4ff);border:1px solid #d5def0;border-radius:12px;box-shadow:inset 0 -28px 0 rgba(255,255,255,.5);overflow:hidden}
+#stage::after{content:"";position:absolute;left:0;right:0;bottom:0;height:128px;background:linear-gradient(180deg,rgba(216,233,255,.65) 0%,rgba(184,209,248,.9) 48%,rgba(152,183,230,.95) 100%);border-top:1px solid rgba(140,169,210,.35);box-shadow:inset 0 22px 40px rgba(15,23,42,.12);z-index:0}
+.stage-player{position:absolute;left:0;top:0;transform:translate(-50%,-100%);display:flex;flex-direction:column;align-items:center;min-width:140px;pointer-events:none;transition:transform .18s ease,left .18s ease,top .18s ease;z-index:1}
+.stage-player .character{pointer-events:auto}
+.stage-player .speech-bubble{position:absolute;bottom:100%;transform:translateY(-12px);background:rgba(255,255,255,.92);padding:8px 12px;border-radius:16px;color:#0f172a;font-size:14px;line-height:1.3;max-width:200px;box-shadow:0 12px 30px rgba(15,23,42,.18);border:1px solid rgba(148,163,184,.35);text-align:center;word-break:break-word}
+.stage-player .speech-bubble::before{content:"";position:absolute;bottom:-9px;left:50%;transform:translateX(-50%);border-width:9px 11px 0 11px;border-style:solid;border-color:rgba(148,163,184,.35) transparent transparent transparent}
+.stage-player .speech-bubble::after{content:"";position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);border-width:8px 10px 0 10px;border-style:solid;border-color:rgba(255,255,255,.92) transparent transparent transparent}
+.stage-player .speech-bubble[hidden]{display:none}
+.stage-player .character-name{margin-top:10px;padding:4px 14px;border-radius:999px;background:rgba(255,255,255,.85);border:1px solid rgba(15,23,42,.1);box-shadow:0 6px 18px rgba(148,163,184,.22);font-size:14px;font-weight:700;color:#0f172a;text-shadow:0 1px 3px rgba(255,255,255,.8);max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.stage-player.me .character-name{background:rgba(79,110,230,.92);color:#fff;border-color:rgba(79,110,230,.4);box-shadow:0 10px 24px rgba(79,110,230,.32);text-shadow:none}
+.char-preview-stage{position:relative;height:280px;width:100%;display:flex;align-items:flex-end;justify-content:center;padding:16px 0;background:linear-gradient(#dceaff,#f3f7ff);border-radius:14px;border:1px solid #d5def6;box-shadow:inset 0 -18px 0 rgba(255,255,255,.55);overflow:hidden}
+.char-preview-stage::after{content:"";position:absolute;left:0;right:0;bottom:0;height:96px;background:linear-gradient(180deg,rgba(214,228,255,.7) 0%,rgba(190,210,247,.9) 60%,rgba(172,195,240,.95) 100%);border-top:1px solid rgba(140,169,210,.35);box-shadow:inset 0 18px 32px rgba(15,23,42,.12);z-index:0}
+.char-preview-stage .stage-player{position:relative;transform:none;min-width:0}
 .overlay.online{position:absolute;left:10px;top:10px;min-width:160px;max-width:40%;padding:8px 10px;border-radius:12px;background:rgba(255,255,255,.45);backdrop-filter:blur(8px);border:1px solid rgba(192,201,220,.6);font-size:14px}
 .overlay.online .user{display:flex;gap:6px;align-items:center;margin:3px 0}
 .overlay.online .dot{width:8px;height:8px;border-radius:50%;background:#22c55e;display:inline-block}
@@ -100,7 +112,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .preview-header{align-self:stretch;display:flex;justify-content:flex-end;margin:0}
 .preview-emotion{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.25);color:#fff;font-size:13px;font-weight:600;min-height:0}
 .character-stage{width:100%;display:flex;justify-content:center;padding:4px 0 0}
-.character{--skin:#f1c7a3;--hair:#1e1e1e;--eyes:#2b4c7e;--underwear:#6aa2ff;--mouth-color:#d45a60;position:relative;width:200px;height:240px;display:flex;align-items:flex-end;justify-content:center}
+.character{--skin:#f1c7a3;--hair:#1e1e1e;--eyes:#2b4c7e;--underwear:#6aa2ff;--mouth-color:#d45a60;--upper-color:#4f81c7;--lower-color:#2f4f7d;--cloak-color:rgba(51,82,130,.92);--cloak-trim:rgba(28,46,82,.9);--shoe-color:#2c3f5e;--headwear-color:#3a6ea5;--headwear-band:#1f2f57;--accessory-color:#f3b234;position:relative;width:200px;height:240px;display:flex;align-items:flex-end;justify-content:center}
 .character,.character *{transition:all .25s ease-in-out}
 .character-shadow{position:absolute;bottom:18px;width:120px;height:22px;background:rgba(8,13,35,.32);filter:blur(12px);border-radius:50%;opacity:.6}
 .character-inner{position:relative;display:flex;flex-direction:column;align-items:center;gap:12px;z-index:1;width:124px}
@@ -162,6 +174,18 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .character[data-style="braids"] .character-hair-back{opacity:1;height:150px;top:18px;border-radius:60px}
 .character[data-style="braids"] .character-hair-back::after{content:"";position:absolute;bottom:10px;left:50%;transform:translateX(-50%);width:18px;height:84px;background:linear-gradient(180deg,var(--hair) 0%,var(--hair) 45%,rgba(255,255,255,.2) 46%,rgba(255,255,255,.2) 54%,var(--hair) 55%,var(--hair) 100%);border-radius:20px}
 .character .character-leg::after{content:"";position:absolute;bottom:-6px;left:50%;transform:translateX(-50%);width:42px;height:16px;background:rgba(255,255,255,.18);border-radius:999px}
+.character.has-upper .character-torso{background:linear-gradient(180deg,var(--upper-color) 0%,rgba(0,0,0,.08) 100%);box-shadow:inset 0 -10px 0 rgba(0,0,0,.12)}
+.character.has-upper .character-underwear{background:linear-gradient(180deg,rgba(255,255,255,.3),rgba(0,0,0,.1)),var(--upper-color);box-shadow:0 5px 0 rgba(255,255,255,.18) inset}
+.character.has-lower .character-underwear{background:linear-gradient(180deg,rgba(255,255,255,.28),rgba(0,0,0,.12)),var(--lower-color);box-shadow:0 6px 0 rgba(0,0,0,.18) inset}
+.character.has-lower .character-leg{background:linear-gradient(180deg,var(--lower-color) 0%,rgba(0,0,0,.18) 100%);box-shadow:inset 0 -14px 0 rgba(0,0,0,.24)}
+.character.has-shoes .character-leg{background:linear-gradient(180deg,var(--lower-color) 0%,var(--shoe-color) 68%,var(--shoe-color) 100%)}
+.character.has-cloak .character-body::before{content:"";position:absolute;top:0;left:50%;transform:translateX(-50%);width:160px;height:188px;background:linear-gradient(180deg,var(--cloak-color) 0%,var(--cloak-trim) 100%);border-radius:74px 74px 52px 52px;z-index:0;box-shadow:0 18px 32px rgba(15,23,42,.28)}
+.character.has-cloak .character-body{z-index:1}
+.character.has-cloak .character-arm{z-index:2}
+.character.has-accessory .character-torso::after{content:"";position:absolute;top:20px;left:50%;transform:translateX(-50%);width:70px;height:70px;border-radius:50%;background:radial-gradient(circle at 50% 30%,rgba(255,255,255,.75),var(--accessory-color));box-shadow:0 0 0 4px rgba(0,0,0,.16) inset,0 0 0 2px rgba(255,255,255,.55);opacity:.85}
+.character.has-head .character-head::before{content:"";position:absolute;top:-34px;left:50%;transform:translateX(-50%);width:124px;height:60px;background:linear-gradient(180deg,var(--headwear-color) 0%,rgba(0,0,0,.2) 100%);border-radius:999px 999px 40px 40px;border:3px solid rgba(255,255,255,.55);box-shadow:0 14px 28px rgba(15,23,42,.28);z-index:5}
+.character.has-head .character-head::after{content:"";position:absolute;top:-6px;left:50%;transform:translateX(-50%);width:146px;height:22px;border-radius:999px;background:linear-gradient(180deg,var(--headwear-band) 0%,rgba(0,0,0,.32) 100%);box-shadow:0 10px 22px rgba(15,23,42,.3);z-index:4}
+.character.has-head .character-hair{filter:brightness(.85)}
 .small{font-size:12px}
 .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .grid3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -20,7 +20,7 @@
 <main class="mur-layout vertical">
   <section class="mur-stage">
     <div class="stage-wrap">
-      <canvas id="stage" width="1100" height="460"></canvas>
+      <div id="stage" class="stage"></div>
       <div class="overlay online" id="online-overlay"></div>
       <div class="arrows">
         <button id="go-left" class="arrow">◀</button>
@@ -48,7 +48,7 @@
     <div class="char-grid">
       <div class="char-preview">
         <div class="char-header">
-          <canvas id="char-canvas" width="280" height="280"></canvas>
+          <div id="char-preview" class="char-preview-stage character-stage"></div>
           <div class="emotion-control">
             <div class="hint-row">
               <span class="lbl">Эмоция</span>
@@ -103,9 +103,6 @@
   </div>
 </div>
 
-<script src="/static/js/avatar_drawing.js"></script>
-<script src="/static/js/outfitLayers.js"></script>
-<script src="/static/js/characterRenderer.js"></script>
 <script src="/static/js/location.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the stage and modal canvases with DOM containers that host the existing `.character` markup
- add layout and outfit styling to support multiple positioned characters and the modal preview
- rewrite the location script to render/update characters via DOM elements and drop the old canvas renderer dependencies

## Testing
- manual verification via uvicorn + Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68d93d907dc8832aaa6ad4079e5a1e10