### PR TITLE
Remove render mode toggle and rely on SVG renderer

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -8,7 +8,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .gender-ico{display:inline-grid;place-items:center;width:22px;height:22px;border-radius:50%;background:#ffd66b;border:1px solid #e8be4a;font-size:12px;color:#1f2937}
 
 .mur-layout.vertical{display:flex;flex-direction:column;gap:16px;padding:16px;max-width:1100px;margin:0 auto}
-.stage-wrap{position:relative}
+.stage-wrap{position:relative;padding-bottom:12px}
 #stage{position:relative;display:block;width:100%;height:460px;background:linear-gradient(#cfe6ff,#eaf4ff);border:1px solid #d5def0;border-radius:12px;box-shadow:inset 0 -28px 0 rgba(255,255,255,.5);overflow:hidden}
 #stage::after{content:"";position:absolute;left:0;right:0;bottom:0;height:128px;background:linear-gradient(180deg,rgba(216,233,255,.65) 0%,rgba(184,209,248,.9) 48%,rgba(152,183,230,.95) 100%);border-top:1px solid rgba(140,169,210,.35);box-shadow:inset 0 22px 40px rgba(15,23,42,.12);z-index:0}
 .stage-player{position:absolute;left:0;top:0;transform:translate(-50%,-100%);display:flex;flex-direction:column;align-items:center;min-width:140px;pointer-events:none;transition:transform .18s ease,left .18s ease,top .18s ease;z-index:1}
@@ -36,12 +36,6 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .arrows{position:absolute;left:10px;bottom:10px;display:flex;gap:8px}
 .arrow{border:1px solid #dfe6f2;background:#fff;border-radius:10px;cursor:pointer;padding:8px 12px;transition:transform .08s}
 .arrow:active{transform:scale(.94)}
-.render-toggle{margin-top:10px;display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:rgba(255,255,255,.55);backdrop-filter:blur(6px);border:1px solid rgba(209,213,233,.6)}
-.render-toggle-label{font-size:13px;color:#334155;font-weight:600}
-.render-toggle-btn{border:1px solid #d5def6;background:#ffffff;border-radius:999px;padding:6px 12px;font-weight:600;color:#1e293b;cursor:pointer;transition:background .12s ease,border-color .12s ease,box-shadow .12s ease,color .12s ease}
-.render-toggle-btn.active{background:#4f6ee6;color:#fff;border-color:#4f6ee6;box-shadow:0 10px 20px rgba(79,110,230,.22)}
-.render-toggle-btn:not(.active):hover{background:#eef2ff;border-color:#c7d2fe}
-.render-toggle-btn[disabled],.render-toggle-btn[aria-disabled="true"]{cursor:not-allowed;opacity:.48;background:#e2e8f0;color:#64748b;border-color:#d5def6;box-shadow:none}
 
 .mur-chat.wide{width:100%}
 .mur-chat h3{margin:6px 0 10px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -26,12 +26,6 @@
         <button id="go-left" class="arrow">◀</button>
         <button id="go-right" class="arrow">▶</button>
       </div>
-      <div class="render-toggle" id="render-toggle" role="group" aria-label="Режим рендера">
-        <span class="render-toggle-label">Рендер:</span>
-        <button type="button" class="render-toggle-btn" data-mode="canvas" aria-pressed="false">Canvas</button>
-        <button type="button" class="render-toggle-btn" data-mode="svg" aria-pressed="false">SVG</button>
-        <button type="button" class="render-toggle-btn" data-mode="webgl" aria-pressed="false">WebGL</button>
-      </div>
     </div>
   </section>
 
@@ -112,8 +106,6 @@
 <script src="/static/js/avatar_drawing.js"></script>
 <script src="/static/js/outfitLayers.js"></script>
 <script src="/static/js/characterRenderer.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" crossorigin="anonymous"></script>
-<script src="/static/js/webglCharacterRenderer.js"></script>
 <script src="/static/js/svgCharacterRenderer.js"></script>
 <script src="/static/js/location.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove the render mode toggle UI and unused WebGL scripts from the location page
- clean up stage layout spacing and drop the associated render-toggle styles
- simplify stage rendering logic to always use the SVG renderer without storing render mode state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9971b4298832aad42bd0d228ee10a