### PR TITLE
Add CSS avatar styling for auth preview

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -120,6 +120,104 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .preview-header{align-self:stretch;display:flex;justify-content:flex-end;margin:0}
 .preview-emotion{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.25);color:#fff;font-size:13px;font-weight:600;min-height:0}
 .character-stage{width:100%;display:flex;justify-content:center;padding:4px 0 0}
+.character{--skin:#f1c7a3;--hair:#1f2937;--eyes:#274472;--mouth-color:#d45a60;--underwear:#6aa2ff;position:relative;width:220px;height:260px;display:flex;align-items:flex-end;justify-content:center;pointer-events:none;transition:transform .25s ease}
+.character-shadow{position:absolute;bottom:12px;left:50%;transform:translateX(-50%);width:120px;height:22px;background:radial-gradient(circle at 50% 50%,rgba(15,23,42,.35),rgba(15,23,42,0));opacity:.4;border-radius:50%}
+.character-inner{position:relative;width:160px;height:220px;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;z-index:1}
+.character-head{position:relative;width:124px;height:128px;display:flex;align-items:center;justify-content:center}
+.character-face{position:relative;width:112px;height:116px;background:var(--skin);border-radius:58% 56% 50% 52%;box-shadow:inset 0 -8px 0 rgba(0,0,0,.05);display:flex;flex-direction:column;align-items:center;justify-content:center;padding-top:26px;z-index:2}
+.character-eyebrows{position:absolute;top:32px;left:50%;width:86px;display:flex;justify-content:space-between;transform:translateX(-50%);transition:transform .2s ease,top .2s ease}
+.character-eyebrow{width:30px;height:8px;background:var(--hair);border-radius:999px;transition:transform .2s ease,top .2s ease,opacity .2s ease}
+.character-eyes{position:absolute;top:58px;left:50%;width:72px;display:flex;justify-content:space-between;transform:translateX(-50%)}
+.character-eye{position:relative;width:18px;height:22px;background:#fff;border-radius:50% 50% 45% 45%;box-shadow:0 3px 0 rgba(15,23,42,.08) inset,0 1px 4px rgba(15,23,42,.12);overflow:hidden}
+.character-eye::after{content:"";position:absolute;top:7px;left:4px;width:10px;height:10px;border-radius:50%;background:var(--eyes);box-shadow:0 0 0 2px rgba(255,255,255,.55) inset}
+.character-eye::before{content:"";position:absolute;top:2px;left:6px;width:6px;height:4px;background:rgba(255,255,255,.85);border-radius:50%}
+.character-mouth{position:absolute;left:50%;bottom:28px;width:48px;height:28px;border-radius:28px;background:transparent;border:4px solid var(--mouth-color);border-top-color:transparent;border-left-color:transparent;border-right-color:transparent;transform:translateX(-50%);transition:all .2s ease}
+.character-hair-back,.character-hair{position:absolute;left:50%;background:var(--hair);transform:translateX(-50%);transition:all .25s ease}
+.character-hair-back{top:10px;width:142px;height:140px;border-radius:56% 56% 44% 44%;z-index:0;box-shadow:0 6px 14px rgba(15,23,42,.25)}
+.character-hair{top:-8px;width:134px;height:96px;border-radius:60% 60% 42% 42%;z-index:3;box-shadow:0 6px 12px rgba(15,23,42,.18)}
+.character-hair::before{content:"";position:absolute;top:6px;left:50%;transform:translateX(-50%);width:120px;height:64px;background:radial-gradient(circle at 50% 10%,rgba(255,255,255,.18) 0 24%,transparent 25%),var(--hair);border-radius:60% 60% 40% 40%;opacity:.95}
+.character-hair::after{content:"";position:absolute;bottom:-16px;left:50%;transform:translateX(-50%);width:94px;height:36px;background:var(--hair);border-radius:48% 52% 70% 70%;box-shadow:0 8px 12px rgba(15,23,42,.18)}
+.character-body{position:relative;width:130px;height:140px;margin-top:-10px;display:flex;align-items:flex-start;justify-content:center}
+.character-torso{position:relative;width:96px;height:92px;background:var(--skin);border-radius:48px 48px 34px 34px;box-shadow:inset 0 -8px 0 rgba(0,0,0,.05);display:flex;align-items:flex-end;justify-content:center;z-index:1}
+.character-underwear{position:absolute;left:50%;bottom:-2px;transform:translateX(-50%);width:94px;height:42px;background:var(--underwear);border-radius:40px 40px 24px 24px;box-shadow:inset 0 -10px 0 rgba(0,0,0,.08)}
+.character-arm{position:absolute;top:18px;width:34px;height:100px;background:var(--skin);border-radius:999px;box-shadow:inset 0 -8px 0 rgba(0,0,0,.05);z-index:0}
+.character-arm.left{left:-12px;transform:rotate(12deg)}
+.character-arm.right{right:-12px;transform:rotate(-12deg)}
+.character-leg{position:absolute;bottom:-70px;width:38px;height:96px;background:var(--skin);border-radius:999px;box-shadow:inset 0 -12px 0 rgba(0,0,0,.05);z-index:0}
+.character-leg.left{left:22px}
+.character-leg.right{right:22px}
+.character.male .character-torso{width:100px;height:96px;border-radius:52px 52px 34px 34px}
+.character.male .character-arm{width:36px;height:106px}
+.character.female .character-torso{width:92px;height:90px;border-radius:50px 50px 40px 40px}
+.character.female .character-underwear{width:88px;border-radius:38px 38px 30px 30px}
+.character.female .character-arm{width:30px;height:96px}
+.character.female .character-leg{width:34px}
+.character.other .character-torso{width:96px}
+.character.other .character-underwear{width:92px}
+.character[data-style="short"] .character-hair{height:74px;border-radius:58% 58% 46% 46%}
+.character[data-style="short"] .character-hair::after{height:28px;border-radius:52% 48% 70% 70%}
+.character[data-style="fade"] .character-hair{height:78px;border-radius:58% 58% 36% 36%;box-shadow:0 4px 10px rgba(15,23,42,.16);background:linear-gradient(180deg,var(--hair) 0%,var(--hair) 58%,rgba(0,0,0,.45) 100%)}
+.character[data-style="fade"] .character-hair::after{height:22px}
+.character[data-style="buzz"] .character-hair{height:54px;border-radius:70px;box-shadow:none}
+.character[data-style="buzz"] .character-hair::before{width:118px;height:48px;border-radius:70px;opacity:.9}
+.character[data-style="buzz"] .character-hair::after{display:none}
+.character[data-style="undercut"] .character-hair{height:88px;border-radius:58% 58% 30% 30%}
+.character[data-style="undercut"] .character-hair::after{height:26px;border-radius:44% 56% 76% 76%;width:110px}
+.character[data-style="mohawk"] .character-hair{width:60px;height:110px;border-radius:50px;background:linear-gradient(90deg,transparent 0%,var(--hair) 30%,var(--hair) 70%,transparent 100%);box-shadow:none}
+.character[data-style="mohawk"] .character-hair::before{display:none}
+.character[data-style="mohawk"] .character-hair::after{display:none}
+.character[data-style="mohawk"] .character-hair-back{width:78px;height:150px;border-radius:50px;background:linear-gradient(90deg,transparent 0%,var(--hair) 40%,var(--hair) 60%,transparent 100%)}
+.character[data-style="curly"] .character-hair,.character[data-style="curly"] .character-hair-back{background:radial-gradient(circle at 12% 20%,rgba(255,255,255,.18) 0 12%,transparent 13%),radial-gradient(circle at 80% 25%,rgba(255,255,255,.12) 0 14%,transparent 15%),radial-gradient(circle at 40% 60%,rgba(255,255,255,.1) 0 16%,transparent 17%),var(--hair)}
+.character[data-style="curly"] .character-hair{height:108px;border-radius:60% 60% 46% 56%}
+.character[data-style="curly"] .character-hair::after{height:38px;border-radius:60% 60% 80% 80%}
+.character[data-style="afro"] .character-hair-back{top:-6px;width:168px;height:176px;border-radius:50%;box-shadow:0 10px 18px rgba(15,23,42,.24)}
+.character[data-style="afro"] .character-hair{display:none}
+.character[data-style="ponytail"] .character-hair::after{content:"";width:42px;height:80px;bottom:-58px;border-radius:40px;background:var(--hair);box-shadow:0 10px 18px rgba(15,23,42,.2)}
+.character[data-style="ponytail"] .character-hair::before{width:120px;height:70px}
+.character[data-style="ponytail"] .character-hair{height:96px;border-radius:60% 60% 40% 40%}
+.character.male[data-style="ponytail"] .character-hair::after{left:65%}
+.character.female[data-style="ponytail"] .character-hair::after{left:72%;height:92px}
+.character.other[data-style="ponytail"] .character-hair::after{left:68%}
+.character[data-style="pixie"] .character-hair{height:84px;border-radius:60% 60% 46% 36%}
+.character[data-style="pixie"] .character-hair::after{width:108px;height:32px;border-radius:36% 64% 78% 78%;left:46%}
+.character[data-style="bob"] .character-hair{height:116px;border-radius:60% 60% 60% 60%;width:150px}
+.character.female[data-style="bob"] .character-hair{width:164px;height:128px}
+.character.other[data-style="bob"] .character-hair{width:158px;height:122px}
+.character[data-style="bob"] .character-hair::after{display:none}
+.character[data-style="long"] .character-hair-back{height:196px;top:-6px;border-radius:60% 60% 50% 50%}
+.character[data-style="long"] .character-hair{height:128px;width:152px;border-radius:58% 58% 64% 64%}
+.character.female[data-style="long"] .character-hair-back{height:216px}
+.character.female[data-style="long"] .character-hair{width:164px}
+.character.other[data-style="long"] .character-hair{width:158px}
+.character[data-style="bun"] .character-hair::after{content:"";width:70px;height:70px;bottom:68px;left:50%;transform:translate(-50%,0);border-radius:50%;background:var(--hair);box-shadow:0 8px 14px rgba(15,23,42,.18)}
+.character[data-style="bun"] .character-hair::before{width:122px;height:72px}
+.character[data-style="bun"] .character-hair{height:90px;border-radius:58% 58% 42% 42%}
+.character[data-style="braids"] .character-hair::before{content:"";top:6px;left:50%;transform:translateX(-50%);width:128px;height:88px;background:radial-gradient(circle at 28% 24%,rgba(255,255,255,.18) 0 18%,transparent 19%),radial-gradient(circle at 72% 26%,rgba(255,255,255,.12) 0 20%,transparent 21%),var(--hair);border-radius:60% 60% 46% 46%}
+.character[data-style="braids"] .character-hair::after{content:"";position:absolute;left:60%;width:34px;height:124px;bottom:-76px;border-radius:22px;background:linear-gradient(180deg,var(--hair) 0%,rgba(0,0,0,.25) 100%);box-shadow:0 8px 16px rgba(15,23,42,.2),inset 0 -6px 0 rgba(255,255,255,.08)}
+.character.male[data-style="braids"] .character-hair::after{left:56%}
+.character.female[data-style="braids"] .character-hair::after{left:64%;width:38px;height:128px}
+.character.other[data-style="braids"] .character-hair::after{left:60%}
+.character[data-style="braids"] .character-hair-back{width:150px;height:168px;border-radius:58% 58% 50% 50%}
+.character[data-emotion="neutral"] .character-mouth{border-top-color:var(--mouth-color);border-left-color:transparent;border-right-color:transparent;height:18px;border-radius:40px/20px}
+.character[data-emotion="smile"] .character-mouth{border-top-color:transparent;border-left-color:transparent;border-right-color:transparent;border-bottom-width:5px;height:30px}
+.character[data-emotion="frown"] .character-mouth{border-bottom-color:transparent;border-left-color:transparent;border-right-color:transparent;border-top-width:5px;height:18px;border-radius:40px/20px;transform:translate(-50%,-6px)}
+.character[data-emotion="surprised"] .character-mouth{width:24px;height:24px;border-radius:50%;border:5px solid var(--mouth-color);border-top-color:var(--mouth-color);transform:translateX(-50%);bottom:34px}
+.character[data-emotion="sleepy"] .character-mouth{width:36px;height:12px;border-width:4px 0 0 0;border-color:var(--mouth-color);border-radius:999px;bottom:34px}
+.character[data-emotion="frown"] .character-eyebrows{top:36px}
+.character[data-emotion="frown"] .character-eyebrow.left{transform:rotate(12deg);top:2px}
+.character[data-emotion="frown"] .character-eyebrow.right{transform:rotate(-12deg);top:2px}
+.character[data-emotion="smile"] .character-eyebrows{top:30px}
+.character[data-emotion="smile"] .character-eyebrow.left{transform:rotate(-6deg)}
+.character[data-emotion="smile"] .character-eyebrow.right{transform:rotate(6deg)}
+.character[data-emotion="surprised"] .character-eyebrows{top:22px}
+.character[data-emotion="surprised"] .character-eyebrow{width:26px;height:6px;border-radius:999px;background:rgba(0,0,0,.2);opacity:.75}
+.character[data-emotion="sleepy"] .character-eyebrows{top:40px}
+.character[data-emotion="sleepy"] .character-eyebrow{height:6px;border-radius:999px;background:var(--hair);opacity:.6}
+.character[data-emotion="sleepy"] .character-eye{height:16px}
+.character[data-emotion="sleepy"] .character-eye::after{top:6px;height:8px}
+.character[data-emotion="sleepy"] .character-eye::before{top:3px;height:2px}
+.character[data-emotion="surprised"] .character-eye{height:28px}
+.character[data-emotion="surprised"] .character-eye::after{top:10px}
 .small{font-size:12px}
 .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .grid3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px}


### PR DESCRIPTION
## Summary
- build a layered CSS avatar using creator color variables for skin, hair, eyes, mouth, and underwear
- add hairstyle variants per data-style and gender classes plus emotion-dependent facial tweaks

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68da27d9c3d0832ab669aef3f8fd3483