### PR TITLE
Add gender-aware underwear rendering

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/characterRenderer.js
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/js/characterRenderer.js
@@ -1253,7 +1253,11 @@
     slots.forEach(slot=>{
       const slotPalette=(basePalette||{})[slot]||{};
       const {equipped, ...defaults}=slotPalette;
-      merged[slot]=Object.assign({}, defaults, (equip && equip[slot] && equipped)?equipped:{});
+      if(!equip || !equip[slot]){
+        merged[slot]={};
+        return;
+      }
+      merged[slot]=Object.assign({}, defaults, equipped||{});
     });
     return merged;
   }


### PR DESCRIPTION
## Summary
- add underwear color helper and lower-underwear drawing function that fall back to gender defaults
- update the default layer order to render underwear when lower slots are empty and only draw clothing when equipped
- ensure outfit palettes ignore default clothing colors when slots are unequipped

## Testing
- manual verification in browser_container (load scene without equipment)
- manual verification in browser_container (equip default shirt and pants)
- manual verification in browser_container (preview modal for a new user)


------
https://chatgpt.com/codex/tasks/task_e_68da39dff60c832a89f28b63d49bf066