### PR TITLE
Replace location stage with static hero preview

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -8,34 +8,18 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .gender-ico{display:inline-grid;place-items:center;width:22px;height:22px;border-radius:50%;background:#ffd66b;border:1px solid #e8be4a;font-size:12px;color:#1f2937}
 
 .mur-layout.vertical{display:flex;flex-direction:column;gap:16px;padding:16px;max-width:1100px;margin:0 auto}
-.stage-wrap{position:relative;padding-bottom:12px}
-#stage{position:relative;display:block;width:100%;height:460px;background:linear-gradient(#cfe6ff,#eaf4ff);border:1px solid #d5def0;border-radius:12px;box-shadow:inset 0 -28px 0 rgba(255,255,255,.5);overflow:hidden}
-#stage::after{content:"";position:absolute;left:0;right:0;bottom:0;height:128px;background:linear-gradient(180deg,rgba(216,233,255,.65) 0%,rgba(184,209,248,.9) 48%,rgba(152,183,230,.95) 100%);border-top:1px solid rgba(140,169,210,.35);box-shadow:inset 0 22px 40px rgba(15,23,42,.12);z-index:0}
-.stage-player{position:absolute;left:0;top:0;transform:translate(-50%,-100%);display:flex;flex-direction:column;align-items:center;min-width:140px;pointer-events:none;transition:transform .18s ease,left .18s ease,top .18s ease;z-index:1}
-.stage-player .avatar-canvas{display:block;width:220px;height:260px;pointer-events:auto}
-.stage-player .avatar-canvas:focus{outline:3px solid rgba(79,110,230,.45);outline-offset:4px}
-.stage-player.me .avatar-canvas{filter:drop-shadow(0 16px 28px rgba(79,110,230,.22))}
-.stage-player .avatar-webgl-wrapper{position:relative;display:flex;align-items:center;justify-content:center;width:220px;height:260px;pointer-events:none}
-.stage-player .avatar-webgl-wrapper[hidden]{display:none}
-.stage-player .avatar-webgl-canvas{width:100%;height:100%;display:block;pointer-events:none}
-.stage-player.me .avatar-webgl-wrapper{filter:drop-shadow(0 16px 28px rgba(79,110,230,.22))}
-.stage-player .avatar-svg-wrapper{position:relative;display:flex;align-items:center;justify-content:center;width:220px;height:260px;pointer-events:none}
-.stage-player .avatar-svg-wrapper[hidden]{display:none}
-.stage-player .avatar-svg{width:100%;height:100%;display:block;pointer-events:none}
-.stage-player .avatar-chat-bubble{position:absolute;left:50%;top:6px;transform:translate(-50%,0);background:rgba(255,255,255,.88);padding:6px 10px;border-radius:12px;box-shadow:0 8px 18px rgba(15,23,42,.16);font-size:14px;line-height:1.3;color:#0f172a;max-width:180px;white-space:pre-wrap;text-align:center;display:none;pointer-events:none}
-.stage-player .avatar-chat-bubble::after{content:"";position:absolute;left:50%;bottom:-6px;transform:translateX(-50%);width:12px;height:6px;background:rgba(255,255,255,.88);clip-path:polygon(50% 100%,0 0,100% 0)}
-.stage-player .avatar-name-label{position:absolute;left:50%;bottom:10px;transform:translateX(-50%);background:rgba(255,255,255,.9);padding:4px 12px;border-radius:999px;font-weight:600;font-size:16px;color:#111827;box-shadow:0 6px 14px rgba(15,23,42,.14);display:none;pointer-events:none}
-.stage-player.me .avatar-svg{filter:drop-shadow(0 16px 28px rgba(79,110,230,.22))}
 .char-preview-stage{position:relative;height:280px;width:100%;display:flex;align-items:flex-end;justify-content:center;padding:16px 0;background:linear-gradient(#dceaff,#f3f7ff);border-radius:14px;border:1px solid #d5def6;box-shadow:inset 0 -18px 0 rgba(255,255,255,.55);overflow:hidden}
 .char-preview-stage::after{content:"";position:absolute;left:0;right:0;bottom:0;height:96px;background:linear-gradient(180deg,rgba(214,228,255,.7) 0%,rgba(190,210,247,.9) 60%,rgba(172,195,240,.95) 100%);border-top:1px solid rgba(140,169,210,.35);box-shadow:inset 0 18px 32px rgba(15,23,42,.12);z-index:0}
-.char-preview-stage .stage-player{position:relative;transform:none;min-width:0}
-.char-preview-stage .avatar-svg-wrapper{position:relative}
-.overlay.online{position:absolute;left:10px;top:10px;min-width:160px;max-width:40%;padding:8px 10px;border-radius:12px;background:rgba(255,255,255,.45);backdrop-filter:blur(8px);border:1px solid rgba(192,201,220,.6);font-size:14px}
-.overlay.online .user{display:flex;gap:6px;align-items:center;margin:3px 0}
-.overlay.online .dot{width:8px;height:8px;border-radius:50%;background:#22c55e;display:inline-block}
-.arrows{position:absolute;left:10px;bottom:10px;display:flex;gap:8px}
-.arrow{border:1px solid #dfe6f2;background:#fff;border-radius:10px;cursor:pointer;padding:8px 12px;transition:transform .08s}
-.arrow:active{transform:scale(.94)}
+.mur-hero{display:flex;flex-wrap:wrap;gap:16px;align-items:flex-start}
+.mur-hero .hero-preview{flex:1 1 360px;min-width:280px}
+.mur-hero .hero-online{flex:0 0 220px;min-width:200px;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,.6);backdrop-filter:blur(8px);border:1px solid rgba(192,201,220,.6);font-size:14px;color:#1e293b;display:flex;flex-direction:column;gap:6px}
+.mur-hero .hero-online b{font-size:15px}
+.mur-hero .hero-online .user{display:flex;gap:6px;align-items:center}
+.mur-hero .hero-online .dot{width:8px;height:8px;border-radius:50%;background:#22c55e;display:inline-block}
+.hero-preview{position:relative}
+.hero-preview .character-stage{position:relative;z-index:1}
+.hero-preview .character-bubble{position:absolute;left:50%;top:18px;transform:translate(-50%,0);background:rgba(255,255,255,.88);padding:6px 10px;border-radius:12px;box-shadow:0 8px 18px rgba(15,23,42,.16);font-size:14px;line-height:1.3;color:#0f172a;max-width:220px;white-space:pre-wrap;text-align:center;pointer-events:none}
+.hero-preview .character-bubble[hidden]{display:none}
 
 .mur-chat.wide{width:100%}
 .mur-chat h3{margin:6px 0 10px}
@@ -119,7 +103,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .creator-right{display:flex;flex-direction:column;align-items:center;gap:12px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.2);border-radius:12px;padding:12px}
 .preview-header{align-self:stretch;display:flex;justify-content:flex-end;margin:0}
 .preview-emotion{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.25);color:#fff;font-size:13px;font-weight:600;min-height:0}
-.character-stage{width:100%;display:flex;justify-content:center;padding:4px 0 0}
+.character-stage{width:100%;display:flex;justify-content:center;padding:4px 0 0;position:relative;z-index:1}
 .character{--skin:#f1c7a3;--hair:#1f2937;--eyes:#274472;--mouth-color:#d45a60;--underwear:#6aa2ff;position:relative;width:220px;height:260px;display:flex;align-items:flex-end;justify-content:center;pointer-events:none;transition:transform .25s ease}
 .character-shadow{position:absolute;bottom:12px;left:50%;transform:translateX(-50%);width:120px;height:22px;background:radial-gradient(circle at 50% 50%,rgba(15,23,42,.35),rgba(15,23,42,0));opacity:.4;border-radius:50%}
 .character-inner{position:relative;width:160px;height:220px;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;z-index:1}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -18,15 +18,42 @@
 </header>
 
 <main class="mur-layout vertical">
-  <section class="mur-stage">
-    <div class="stage-wrap">
-      <div id="stage" class="stage"></div>
-      <div class="overlay online" id="online-overlay"></div>
-      <div class="arrows">
-        <button id="go-left" class="arrow">◀</button>
-        <button id="go-right" class="arrow">▶</button>
+  <section class="mur-hero">
+    <div class="char-preview-stage hero-preview">
+      <div class="character-stage">
+        <div id="location-character" class="character other" data-style="short" data-emotion="smile">
+          <div class="character-shadow"></div>
+          <div class="character-inner">
+            <div class="character-head">
+              <div class="character-hair-back"></div>
+              <div class="character-face">
+                <div class="character-eyebrows">
+                  <span class="character-eyebrow left"></span>
+                  <span class="character-eyebrow right"></span>
+                </div>
+                <div class="character-eyes">
+                  <span class="character-eye left"></span>
+                  <span class="character-eye right"></span>
+                </div>
+                <div class="character-mouth"></div>
+              </div>
+              <div class="character-hair"></div>
+            </div>
+            <div class="character-body">
+              <div class="character-arm left"></div>
+              <div class="character-arm right"></div>
+              <div class="character-torso">
+                <div class="character-underwear"></div>
+              </div>
+              <div class="character-leg left"></div>
+              <div class="character-leg right"></div>
+            </div>
+          </div>
+        </div>
       </div>
+      <div id="location-bubble" class="character-bubble" hidden></div>
     </div>
+    <div class="hero-online" id="online-overlay"></div>
   </section>
 
   <section class="mur-chat wide">
@@ -48,7 +75,39 @@
     <div class="char-grid">
       <div class="char-preview">
         <div class="char-header">
-          <div id="char-preview" class="char-preview-stage character-stage"></div>
+          <div class="char-preview-stage">
+            <div class="character-stage">
+              <div id="char-preview-character" class="character other" data-style="short" data-emotion="smile">
+                <div class="character-shadow"></div>
+                <div class="character-inner">
+                  <div class="character-head">
+                    <div class="character-hair-back"></div>
+                    <div class="character-face">
+                      <div class="character-eyebrows">
+                        <span class="character-eyebrow left"></span>
+                        <span class="character-eyebrow right"></span>
+                      </div>
+                      <div class="character-eyes">
+                        <span class="character-eye left"></span>
+                        <span class="character-eye right"></span>
+                      </div>
+                      <div class="character-mouth"></div>
+                    </div>
+                    <div class="character-hair"></div>
+                  </div>
+                  <div class="character-body">
+                    <div class="character-arm left"></div>
+                    <div class="character-arm right"></div>
+                    <div class="character-torso">
+                      <div class="character-underwear"></div>
+                    </div>
+                    <div class="character-leg left"></div>
+                    <div class="character-leg right"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
           <div class="emotion-control">
             <div class="hint-row">
               <span class="lbl">Эмоция</span>
@@ -103,10 +162,6 @@
   </div>
 </div>
 
-<script src="/static/js/avatar_drawing.js"></script>
-<script src="/static/js/outfitLayers.js"></script>
-<script src="/static/js/characterRenderer.js"></script>
-<script src="/static/js/svgCharacterRenderer.js"></script>
 <script src="/static/js/location.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the location stage block with the static character structure used in auth and wire it to new preview ids
- remove the unused rendering scripts and simplify location.js to update avatar appearance via DOM attributes
- prune legacy stage styling while adding hero layout and bubble styles for the new preview and online list

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68da3f4555e4832a927eaf7218e82231