### PR TITLE
Add movement controls for location character

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -20,9 +20,18 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .mur-hero .hero-online .user{display:flex;gap:6px;align-items:center}
 .mur-hero .hero-online .dot{width:8px;height:8px;border-radius:50%;background:#22c55e;display:inline-block}
 .hero-preview{position:relative}
+.hero-preview-controls{display:flex;align-items:flex-end;justify-content:center;gap:12px;width:100%}
+.hero-preview-controls .character-stage{flex:1 1 auto;display:flex;justify-content:center;align-items:flex-end}
+.hero-preview-controls .hero-move-button{background:rgba(255,255,255,.72);border:1px solid rgba(79,110,230,.35);border-radius:999px;width:44px;height:44px;display:grid;place-items:center;font-size:18px;font-weight:600;color:#1e293b;cursor:pointer;box-shadow:0 10px 18px rgba(15,23,42,.12);transition:transform .12s ease,box-shadow .12s ease,background-color .12s ease,color .12s ease}
+.hero-preview-controls .hero-move-button:hover:not(:disabled){transform:translateY(-1px);box-shadow:0 14px 26px rgba(15,23,42,.16);background:rgba(255,255,255,.9)}
+.hero-preview-controls .hero-move-button:focus-visible{outline:3px solid rgba(79,110,230,.55);outline-offset:2px}
+.hero-preview-controls .hero-move-button:disabled{opacity:.45;cursor:not-allowed;transform:none;box-shadow:none}
+.hero-preview-controls .hero-move-button[hidden]{display:none}
 .hero-preview .character-stage{position:relative;z-index:1}
 .hero-preview .character-bubble{position:absolute;left:50%;top:18px;transform:translate(-50%,0);background:rgba(255,255,255,.88);padding:6px 10px;border-radius:12px;box-shadow:0 8px 18px rgba(15,23,42,.16);font-size:14px;line-height:1.3;color:#0f172a;max-width:220px;white-space:pre-wrap;text-align:center;pointer-events:none}
 .hero-preview .character-bubble[hidden]{display:none}
+
+#location-character{--translate-x:0px;transform:translate3d(var(--translate-x),0,0)}
 
 .mur-chat.wide{width:100%}
 .mur-chat h3{margin:6px 0 10px}

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -20,36 +20,40 @@
 <main class="mur-layout vertical">
   <section class="mur-hero">
     <div class="char-preview-stage hero-preview">
-      <div class="character-stage">
-        <div id="location-character" class="character other" data-style="short" data-emotion="smile">
-          <div class="character-shadow"></div>
-          <div class="character-inner">
-            <div class="character-head">
-              <div class="character-hair-back"></div>
-              <div class="character-face">
-                <div class="character-eyebrows">
-                  <span class="character-eyebrow left"></span>
-                  <span class="character-eyebrow right"></span>
+      <div class="hero-preview-controls">
+        <button type="button" class="hero-move-button" data-action="move-left" aria-label="Передвинуть персонажа влево" title="Влево">◀</button>
+        <div class="character-stage">
+          <div id="location-character" class="character other" data-style="short" data-emotion="smile">
+            <div class="character-shadow"></div>
+            <div class="character-inner">
+              <div class="character-head">
+                <div class="character-hair-back"></div>
+                <div class="character-face">
+                  <div class="character-eyebrows">
+                    <span class="character-eyebrow left"></span>
+                    <span class="character-eyebrow right"></span>
+                  </div>
+                  <div class="character-eyes">
+                    <span class="character-eye left"></span>
+                    <span class="character-eye right"></span>
+                  </div>
+                  <div class="character-mouth"></div>
                 </div>
-                <div class="character-eyes">
-                  <span class="character-eye left"></span>
-                  <span class="character-eye right"></span>
+                <div class="character-hair"></div>
+              </div>
+              <div class="character-body">
+                <div class="character-arm left"></div>
+                <div class="character-arm right"></div>
+                <div class="character-torso">
+                  <div class="character-underwear"></div>
                 </div>
-                <div class="character-mouth"></div>
+                <div class="character-leg left"></div>
+                <div class="character-leg right"></div>
               </div>
-              <div class="character-hair"></div>
-            </div>
-            <div class="character-body">
-              <div class="character-arm left"></div>
-              <div class="character-arm right"></div>
-              <div class="character-torso">
-                <div class="character-underwear"></div>
-              </div>
-              <div class="character-leg left"></div>
-              <div class="character-leg right"></div>
             </div>
           </div>
         </div>
+        <button type="button" class="hero-move-button" data-action="move-right" aria-label="Передвинуть персонажа вправо" title="Вправо">▶</button>
       </div>
       <div id="location-bubble" class="character-bubble" hidden></div>
       <div class="hero-online" id="online-overlay"></div>


### PR DESCRIPTION
## Summary
- add left and right movement buttons to the hero preview container
- refactor movement handling into a reusable helper shared by keyboard and buttons
- style the new controls and translate the location character based on its position

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da57ec8974832a859ec71d784d9f78