### PR TITLE
Adjust hero online panel positioning

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -14,7 +14,7 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .mur-hero{display:flex;flex-wrap:wrap;gap:16px;align-items:flex-start}
 .mur-hero .hero-preview{flex:1 1 360px;min-width:280px}
 .mur-hero .hero-online{padding:12px 14px;border-radius:14px;background:rgba(255,255,255,.35);backdrop-filter:blur(12px);border:1px solid rgba(192,201,220,.45);font-size:14px;color:#1e293b;display:flex;flex-direction:column;gap:6px;box-shadow:0 18px 36px rgba(15,23,42,.12)}
-.hero-preview .hero-online{position:absolute;right:24px;bottom:28px;width:min(260px,calc(100% - 48px));z-index:2}
+.hero-preview .hero-online{position:absolute;top:24px;right:24px;width:min(260px,calc(100% - 48px));z-index:2}
 .hero-preview .hero-online::before{content:"";position:absolute;inset:0;border-radius:inherit;background:rgba(255,255,255,.08);pointer-events:none}
 .hero-preview .hero-online>*{position:relative;z-index:1}
 .mur-hero .hero-online b{font-size:15px}
@@ -29,8 +29,10 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .hero-preview-controls .hero-move-button:disabled{opacity:.45;cursor:not-allowed;transform:none;box-shadow:none}
 .hero-preview-controls .hero-move-button[hidden]{display:none}
 .hero-preview .character-stage{position:relative;z-index:2}
-.hero-preview .character-bubble{position:absolute;left:50%;top:18px;transform:translate(-50%,0);background:rgba(255,255,255,.88);padding:6px 10px;border-radius:12px;box-shadow:0 8px 18px rgba(15,23,42,.16);font-size:14px;line-height:1.3;color:#0f172a;max-width:220px;white-space:pre-wrap;text-align:center;pointer-events:none}
+.hero-preview .character-bubble{position:absolute;left:50%;top:18px;transform:translate(-50%,0);background:rgba(255,255,255,.88);padding:6px 10px;border-radius:12px;box-shadow:0 8px 18px rgba(15,23,42,.16);font-size:14px;line-height:1.3;color:#0f172a;max-width:220px;white-space:pre-wrap;text-align:center;pointer-events:none;z-index:1}
 .hero-preview .character-bubble[hidden]{display:none}
+
+@media (max-width:640px){.char-preview-stage.hero-preview{padding-top:140px;padding-right:160px}.hero-preview .hero-online{top:16px;right:16px;width:min(180px,calc(100% - 32px))}.hero-preview .character-bubble{top:164px}}
 
 #location-character{--translate-x:0px;transform:translate3d(var(--translate-x),0,0) translateX(-50%)}
 


### PR DESCRIPTION
## Summary
- anchor the hero online overlay to the top-right corner of the preview and ensure the speech bubble layers below it
- add mobile-specific spacing so the overlay clears the character on narrow screens while keeping desktop layout unchanged

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68da67c3b0fc832a8b7fe23b1f966edc