### PR TITLE
Add active state styling for hero move buttons

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -25,6 +25,8 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .hero-preview-controls .character-stage{flex:1 1 auto;height:100%;position:relative;min-height:0}
 .hero-preview-controls .hero-move-button{background:rgba(255,255,255,.72);border:1px solid rgba(79,110,230,.35);border-radius:999px;width:44px;height:44px;display:grid;place-items:center;font-size:18px;font-weight:600;color:#1e293b;cursor:pointer;box-shadow:0 10px 18px rgba(15,23,42,.12);transition:transform .12s ease,box-shadow .12s ease,background-color .12s ease,color .12s ease}
 .hero-preview-controls .hero-move-button:hover:not(:disabled){transform:translateY(-1px);box-shadow:0 14px 26px rgba(15,23,42,.16);background:rgba(255,255,255,.9)}
+.hero-preview-controls .hero-move-button:active:not(:disabled),
+.hero-preview-controls .hero-move-button[aria-pressed="true"]:not(:disabled){transform:translateY(1px);box-shadow:0 6px 12px rgba(15,23,42,.1)}
 .hero-preview-controls .hero-move-button:focus-visible{outline:3px solid rgba(79,110,230,.55);outline-offset:2px}
 .hero-preview-controls .hero-move-button:disabled{opacity:.45;cursor:not-allowed;transform:none;box-shadow:none}
 .hero-preview-controls .hero-move-button[hidden]{display:none}


### PR DESCRIPTION
## Summary
- add active and aria-pressed styling for hero move buttons so they depress with lower shadow when pressed

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68daa7f7c648832ab2a315095ed8d39b