### PR TITLE
Fix location speech bubble alignment with character

### DIFF
--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/static/css/styles.css
@@ -31,10 +31,10 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;backg
 .hero-preview-controls .hero-move-button:disabled{opacity:.45;cursor:not-allowed;transform:none;box-shadow:none}
 .hero-preview-controls .hero-move-button[hidden]{display:none}
 .hero-preview .character-stage{position:relative;z-index:2}
-.hero-preview .character-bubble{position:absolute;left:50%;top:18px;transform:translate(-50%,0);background:rgba(255,255,255,.88);padding:6px 10px;border-radius:12px;box-shadow:0 8px 18px rgba(15,23,42,.16);font-size:14px;line-height:1.3;color:#0f172a;max-width:220px;white-space:pre-wrap;text-align:center;pointer-events:none;z-index:1}
+.hero-preview .character-bubble{position:absolute;bottom:calc(100% + 18px);left:50%;transform:translateX(-50%);background:rgba(255,255,255,.88);padding:6px 10px;border-radius:12px;box-shadow:0 8px 18px rgba(15,23,42,.16);font-size:14px;line-height:1.3;color:#0f172a;max-width:220px;white-space:pre-wrap;text-align:center;pointer-events:none;z-index:1}
 .hero-preview .character-bubble[hidden]{display:none}
 
-@media (max-width:640px){.char-preview-stage.hero-preview{padding-top:140px;padding-right:160px}.hero-preview .hero-online{top:16px;right:16px;width:min(180px,calc(100% - 32px))}.hero-preview .character-bubble{top:164px}}
+@media (max-width:640px){.char-preview-stage.hero-preview{padding-top:140px;padding-right:160px}.hero-preview .hero-online{top:16px;right:16px;width:min(180px,calc(100% - 32px))}}
 
 #location-character{--translate-x:0px;--scale:.75;transform-origin:50% 100%;transform:translate3d(var(--translate-x),0,0) translateX(-50%) scale(var(--scale))}
 

--- a/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
+++ b/collective_prediction_clean_full_v3_7_ux7_full_creator_v5/app/templates/location.html
@@ -52,11 +52,11 @@
                 <div class="character-leg right"></div>
               </div>
             </div>
+            <div id="location-bubble" class="character-bubble" hidden></div>
           </div>
         </div>
         <button type="button" class="hero-move-button" data-action="move-right" aria-label="Передвинуть персонажа вправо" title="Вправо">▶</button>
       </div>
-      <div id="location-bubble" class="character-bubble" hidden></div>
       <div class="hero-online" id="online-overlay"></div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- move the location speech bubble markup inside the character container so it follows transforms
- reposition the bubble above the avatar by anchoring it to the character rather than the stage

## Testing
- browser_container.run_playwright_script

------
https://chatgpt.com/codex/tasks/task_e_68daad7b8170832a8fbbf9fc5fedbc39